### PR TITLE
Draft: Implement synchronisation between ALSA and Spotify volume 

### DIFF
--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -25,8 +25,9 @@ type AppPlayer struct {
 	stop   chan struct{}
 	logout chan *AppPlayer
 
-	player            *player.Player
-	initialVolumeOnce sync.Once
+	player               *player.Player
+	initialVolumeOnce    sync.Once
+	externalVolumeUpdate chan float32
 
 	spotConnId string
 

--- a/output/output.go
+++ b/output/output.go
@@ -41,10 +41,12 @@ type NewOutputOptions struct {
 
 	// InitialVolume specifies the initial output volume.
 	InitialVolume float32
+
+	ExternalVolumeUpdate chan float32
 }
 
 func NewOutput(options *NewOutputOptions) (*Output, error) {
-	out, err := newOutput(options.Reader, options.SampleRate, options.ChannelCount, options.Device, options.Mixer, options.InitialVolume)
+	out, err := newOutput(options.Reader, options.SampleRate, options.ChannelCount, options.Device, options.Mixer, options.InitialVolume, options.ExternalVolumeUpdate)
 	if err != nil {
 		return nil, err
 	}

--- a/player/player.go
+++ b/player/player.go
@@ -62,7 +62,7 @@ type playerCmdDataSet struct {
 	paused  bool
 }
 
-func NewPlayer(sp *spclient.Spclient, audioKey *audio.KeyProvider, normalisationEnabled bool, normalisationPregain float32, countryCode *string, device, mixer string, volumeSteps uint32, externalVolume bool) (*Player, error) {
+func NewPlayer(sp *spclient.Spclient, audioKey *audio.KeyProvider, normalisationEnabled bool, normalisationPregain float32, countryCode *string, device, mixer string, volumeSteps uint32, externalVolume bool, externalVolumeUpdate chan float32) (*Player, error) {
 	p := &Player{
 		sp:                   sp,
 		audioKey:             audioKey,
@@ -71,12 +71,13 @@ func NewPlayer(sp *spclient.Spclient, audioKey *audio.KeyProvider, normalisation
 		countryCode:          countryCode,
 		newOutput: func(reader librespot.Float32Reader, volume float32) (*output.Output, error) {
 			return output.NewOutput(&output.NewOutputOptions{
-				Reader:        reader,
-				SampleRate:    SampleRate,
-				ChannelCount:  Channels,
-				Device:        device,
-				Mixer:         mixer,
-				InitialVolume: volume,
+				Reader:               reader,
+				SampleRate:           SampleRate,
+				ChannelCount:         Channels,
+				Device:               device,
+				Mixer:                mixer,
+				InitialVolume:        volume,
+				ExternalVolumeUpdate: externalVolumeUpdate,
 			})
 		},
 		externalVolume: externalVolume,


### PR DESCRIPTION
This is a first POC for implementing this feature.
I've never written any GO before, so it would be nice if someone could give me some feedback, where I could make improvements. 

Features:
- [x] Everytime the ALSA volume is changed, the volume in spotify also changes.
- [ ] Sync the volume from ALSA to Spotify on connect or startup
- [ ] Make the behaviour configurable 
     - [ ] The synchronization should only be enabled, if externalVolume is true
     - [ ] The ALSA control name needs to be configurable (currently hardcoded as master)
     - [ ] ...