### PR TITLE
fix: don't update initial volume when a mixer is configured.

### DIFF
--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -74,7 +74,7 @@ func (p *AppPlayer) handleDealerMessage(msg dealer.Message) error {
 			return fmt.Errorf("failed initial state put: %w", err)
 		}
 
-		if !p.app.cfg.ExternalVolume && len(*p.app.cfg.MixerDevice) != 0 {
+		if !p.app.cfg.ExternalVolume && len(*p.app.cfg.MixerDevice) == 0 {
 			// update initial volume
 			p.initialVolumeOnce.Do(func() {
 				p.updateVolume(*p.app.cfg.InitialVolume * player.MaxStateVolume / *p.app.cfg.VolumeSteps)


### PR DESCRIPTION
Fix an oversight in the original alsa mixer implementation. 