### PR TITLE
chore: list dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ go build -o go-librespot-daemon ./cmd/daemon
 
 To crosscompile for different architectures the `GOOS` and `GOARCH` environment variables can be used.
 
+### Dependencies
+
+You need to have the following installed:
+
+  * Go 1.22 or higher
+  * libogg
+  * libvorbis
+  * libasound2
+
+You can install the 3 libraries in Debian (and Ubuntu/Raspbian) using the following command:
+
+    sudo apt-get install libogg-dev libvorbis-dev libasound2-dev
+
+You can install a newer Go version from the [Go website](https://go.dev/dl/).
+
 ## Development
 
 To recompile protobuf definitions use:


### PR DESCRIPTION
Thanks for this daemon!
To make setup a bit easier, I listed the extra dependencies that I had to install. There might be more, but these were the ones I had to install on a Raspberry Pi OS install.