### PR TITLE
Default configuration file

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -351,13 +351,19 @@ type Config struct {
 }
 
 func loadConfig(cfg *Config) error {
-	flag.StringVar(&cfg.ConfigPath, "config_path", "config.yml", "the configuration file path")
+	flag.StringVar(&cfg.ConfigPath, "config_path", "", "the configuration file path (default config.yml)")
 	flag.StringVar(&cfg.CredentialsPath, "credentials_path", "credentials.json", "the credentials file path")
 	flag.Parse()
 
-	configBytes, err := os.ReadFile(cfg.ConfigPath)
+	configPath := cfg.ConfigPath
+	if configPath == "" {
+		configPath = "config.yml"
+	}
+	configBytes, err := os.ReadFile(configPath)
 	if err != nil {
-		return fmt.Errorf("failed reading configuration file: %w", err)
+		if cfg.ConfigPath != "" || !os.IsNotExist(err) {
+			return fmt.Errorf("failed reading configuration file: %w", err)
+		}
 	}
 
 	if err := yaml.Unmarshal(configBytes, cfg); err != nil {

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -377,6 +377,10 @@ func loadConfig(cfg *Config) error {
 	if cfg.DeviceName == nil {
 		cfg.DeviceName = new(string)
 		*cfg.DeviceName = "go-librespot"
+		hostname, _ := os.Hostname()
+		if hostname != "" {
+			*cfg.DeviceName += " " + hostname
+		}
 	}
 	if cfg.Credentials.Type == "" {
 		cfg.Credentials.Type = "zeroconf"

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -378,6 +378,9 @@ func loadConfig(cfg *Config) error {
 		cfg.DeviceName = new(string)
 		*cfg.DeviceName = "go-librespot"
 	}
+	if cfg.Credentials.Type == "" {
+		cfg.Credentials.Type = "zeroconf"
+	}
 	if cfg.DeviceType == nil {
 		cfg.DeviceType = new(string)
 		*cfg.DeviceType = "computer"


### PR DESCRIPTION
Instead of failing altogether, this PR falls back to a default configuration file if `-config_path` is not set.
The default configuration file would be the equivalent of:

```yaml
device_name: go-librespot <hostname>
credentials:
  type: zeroconf
```