### PR TITLE
fix: map audio logarithmically, not linearly

### DIFF
--- a/output/driver_unix.go
+++ b/output/driver_unix.go
@@ -282,8 +282,12 @@ func (out *output) writeLoop() error {
 		}
 
 		if !out.mixerEnabled && !out.externalVolume {
+			// Map volume (in percent) to what is perceived as linear by
+			// humans. This is the same as math.Pow(out.volume, 2) but simpler.
+			volume := out.volume * out.volume
+
 			for i := 0; i < len(floats); i++ {
-				floats[i] *= out.volume
+				floats[i] *= volume
 			}
 		}
 


### PR DESCRIPTION
Audio is perceived by humans in a logarithmic way. For a good explanation, see:
https://www.dr-lex.be/info-stuff/volumecontrols.html#about
This PR fixes the volume slider to be logarithmic.

OS volume controls (PulseAudio etc) do something similar, for the same reason.