### PR TITLE
fix: avoid race conditions

### DIFF
--- a/ap/ap.go
+++ b/ap/ap.go
@@ -47,6 +47,7 @@ type Accesspoint struct {
 	recvChans         map[PacketType][]chan Packet
 	recvChansLock     sync.RWMutex
 	lastPongAck       time.Time
+	lastPongAckLock   sync.Mutex
 
 	// connMu is held for writing when performing reconnection and for reading mainly when accessing welcome
 	// or sending packets. If it's not held, a valid connection (and APWelcome) is available. Be careful not to deadlock
@@ -263,7 +264,9 @@ loop:
 				}
 			case PacketTypePongAck:
 				log.Tracef("received accesspoint pong ack")
+				ap.lastPongAckLock.Lock()
 				ap.lastPongAck = time.Now()
+				ap.lastPongAckLock.Unlock()
 				continue
 			default:
 				ap.recvChansLock.RLock()
@@ -323,8 +326,11 @@ loop:
 		case <-ap.pongAckTickerStop:
 			break loop
 		case <-ticker.C:
-			if time.Since(ap.lastPongAck) > pongAckInterval {
-				log.Errorf("did not receive last pong ack from accesspoint, %.0fs passed", time.Since(ap.lastPongAck).Seconds())
+			ap.lastPongAckLock.Lock()
+			timePassed := time.Since(ap.lastPongAck)
+			ap.lastPongAckLock.Unlock()
+			if timePassed > pongAckInterval {
+				log.Errorf("did not receive last pong ack from accesspoint, %.0fs passed", timePassed.Seconds())
 
 				// closing the connection should make the read on the "recvLoop" fail,
 				// continue hoping for a new connection


### PR DESCRIPTION
These race conditions may seem harmless, and maybe they are unlikely to cause real trouble, but:

 1. There is a theoretical chance they do. A partially written time value in one goroutine may result in an invalid (and very wrong) time in another, leading to misbehaving code.
 2. They introduce noise, and make it more difficult to find&fix other race conditions.