### PR TITLE
chore: run goimports

### DIFF
--- a/ap/ap.go
+++ b/ap/ap.go
@@ -11,6 +11,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/dh"
@@ -20,11 +26,6 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/net/proxy"
 	"google.golang.org/protobuf/proto"
-	"io"
-	"net"
-	"os"
-	"sync"
-	"time"
 )
 
 const pongAckInterval = 120 * time.Second

--- a/ap/conn.go
+++ b/ap/conn.go
@@ -3,8 +3,9 @@ package ap
 import (
 	"encoding/binary"
 	"fmt"
-	"google.golang.org/protobuf/proto"
 	"io"
+
+	"google.golang.org/protobuf/proto"
 )
 
 func writeMessage(w io.Writer, withHello bool, m proto.Message) error {

--- a/ap/shannon.go
+++ b/ap/shannon.go
@@ -3,10 +3,11 @@ package ap
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/devgianlu/shannon"
 	"io"
 	"net"
 	"sync"
+
+	"github.com/devgianlu/shannon"
 )
 
 type shannonConn struct {

--- a/apresolve/resolve.go
+++ b/apresolve/resolve.go
@@ -3,13 +3,14 @@ package apresolve
 import (
 	"encoding/json"
 	"fmt"
-	librespot "github.com/devgianlu/go-librespot"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
+
+	librespot "github.com/devgianlu/go-librespot"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
 type apResolveResponse struct {

--- a/audio/chunked_reader.go
+++ b/audio/chunked_reader.go
@@ -2,9 +2,6 @@ package audio
 
 import (
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
-	librespot "github.com/devgianlu/go-librespot"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"net/url"
@@ -12,6 +9,10 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	librespot "github.com/devgianlu/go-librespot"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/audio/metadata.go
+++ b/audio/metadata.go
@@ -5,11 +5,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
+	"math"
+
 	librespot "github.com/devgianlu/go-librespot"
 	log "github.com/sirupsen/logrus"
 	"github.com/xlab/vorbis-go/vorbis"
-	"io"
-	"math"
 )
 
 const (

--- a/audio/provider.go
+++ b/audio/provider.go
@@ -5,10 +5,11 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"sync"
+
 	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/ap"
 	log "github.com/sirupsen/logrus"
-	"sync"
 )
 
 type KeyProvider struct {

--- a/cmd/daemon/api_server.go
+++ b/cmd/daemon/api_server.go
@@ -6,16 +6,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	librespot "github.com/devgianlu/go-librespot"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"
 	"net/url"
-	"nhooyr.io/websocket"
-	"nhooyr.io/websocket/wsjson"
 	"strings"
 	"sync"
 	"time"
+
+	librespot "github.com/devgianlu/go-librespot"
+	log "github.com/sirupsen/logrus"
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
 )
 
 const timeout = 10 * time.Second

--- a/cmd/daemon/controls.go
+++ b/cmd/daemon/controls.go
@@ -3,6 +3,10 @@ package main
 import (
 	"errors"
 	"fmt"
+	"math"
+	"strconv"
+	"time"
+
 	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/player"
 	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
@@ -10,9 +14,6 @@ import (
 	"github.com/devgianlu/go-librespot/tracks"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
-	"math"
-	"strconv"
-	"time"
 )
 
 func (p *AppPlayer) prefetchNext() {

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -6,6 +6,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/devgianlu/go-librespot/apresolve"
 	"github.com/devgianlu/go-librespot/output"
 	"github.com/devgianlu/go-librespot/player"
@@ -15,10 +20,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/rand"
 	"gopkg.in/yaml.v3"
-	"math"
-	"os"
-	"strings"
-	"time"
 )
 
 type App struct {

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -5,6 +5,12 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
+	"math"
+	"strings"
+	"sync"
+	"time"
+
 	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/ap"
 	"github.com/devgianlu/go-librespot/dealer"
@@ -15,11 +21,6 @@ import (
 	"github.com/devgianlu/go-librespot/tracks"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
-	"io"
-	"math"
-	"strings"
-	"sync"
-	"time"
 )
 
 type AppPlayer struct {

--- a/cmd/daemon/state.go
+++ b/cmd/daemon/state.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"time"
+
 	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/dealer"
 	"github.com/devgianlu/go-librespot/player"
 	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
 	"github.com/devgianlu/go-librespot/tracks"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 type State struct {

--- a/dealer/dealer.go
+++ b/dealer/dealer.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
+	"net/http"
+	"sync"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	librespot "github.com/devgianlu/go-librespot"
 	log "github.com/sirupsen/logrus"
-	"math"
-	"net/http"
 	"nhooyr.io/websocket"
-	"sync"
-	"time"
 )
 
 const (

--- a/dealer/recv.go
+++ b/dealer/recv.go
@@ -6,11 +6,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"reflect"
 	"strings"
+
+	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
+	log "github.com/sirupsen/logrus"
 )
 
 type messageReceiver struct {

--- a/ids.go
+++ b/ids.go
@@ -3,10 +3,11 @@ package go_librespot
 import (
 	"encoding/hex"
 	"fmt"
-	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
 	"math/big"
 	"regexp"
 	"strings"
+
+	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
 )
 
 var UriRegexp = regexp.MustCompile("^spotify:([a-z]+):([0-9a-zA-Z]{21,22})$")

--- a/login5/hashcash.go
+++ b/login5/hashcash.go
@@ -2,10 +2,11 @@ package login5
 
 import (
 	"crypto/sha1"
-	"github.com/devgianlu/go-librespot/proto/google"
-	challengespb "github.com/devgianlu/go-librespot/proto/spotify/login5/v3/challenges"
 	"math/bits"
 	"time"
+
+	"github.com/devgianlu/go-librespot/proto/google"
+	challengespb "github.com/devgianlu/go-librespot/proto/spotify/login5/v3/challenges"
 )
 
 func checkHashcash(hash []byte, length int) bool {

--- a/login5/login5.go
+++ b/login5/login5.go
@@ -3,16 +3,17 @@ package login5
 import (
 	"bytes"
 	"fmt"
-	librespot "github.com/devgianlu/go-librespot"
-	pb "github.com/devgianlu/go-librespot/proto/spotify/login5/v3"
-	credentialspb "github.com/devgianlu/go-librespot/proto/spotify/login5/v3/credentials"
-	log "github.com/sirupsen/logrus"
-	"google.golang.org/protobuf/proto"
 	"io"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
+
+	librespot "github.com/devgianlu/go-librespot"
+	pb "github.com/devgianlu/go-librespot/proto/spotify/login5/v3"
+	credentialspb "github.com/devgianlu/go-librespot/proto/spotify/login5/v3/credentials"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/proto"
 )
 
 type Login5 struct {

--- a/output/driver_unix.go
+++ b/output/driver_unix.go
@@ -10,12 +10,13 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	librespot "github.com/devgianlu/go-librespot"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 	"io"
 	"sync"
 	"unsafe"
+
+	librespot "github.com/devgianlu/go-librespot"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 const (

--- a/output/mixer_unix.go
+++ b/output/mixer_unix.go
@@ -10,8 +10,9 @@ package output
 import "C"
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"unsafe"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func (out *output) setupMixer() error {

--- a/platform.go
+++ b/platform.go
@@ -1,9 +1,10 @@
 package go_librespot
 
 import (
+	"runtime"
+
 	spotifypb "github.com/devgianlu/go-librespot/proto/spotify"
 	clienttokenpb "github.com/devgianlu/go-librespot/proto/spotify/clienttoken/data/v0"
-	"runtime"
 )
 
 func GetOS() spotifypb.Os {

--- a/player.go
+++ b/player.go
@@ -2,6 +2,7 @@ package go_librespot
 
 import (
 	"errors"
+
 	metadatapb "github.com/devgianlu/go-librespot/proto/spotify/metadata"
 )
 

--- a/player/player.go
+++ b/player/player.go
@@ -2,6 +2,8 @@ package player
 
 import (
 	"fmt"
+	"time"
+
 	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/audio"
 	"github.com/devgianlu/go-librespot/output"
@@ -10,7 +12,6 @@ import (
 	"github.com/devgianlu/go-librespot/spclient"
 	"github.com/devgianlu/go-librespot/vorbis"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 const SampleRate = 44100

--- a/player/restriction.go
+++ b/player/restriction.go
@@ -1,9 +1,10 @@
 package player
 
 import (
+	"strings"
+
 	librespot "github.com/devgianlu/go-librespot"
 	metadatapb "github.com/devgianlu/go-librespot/proto/spotify/metadata"
-	"strings"
 )
 
 func isMediaRestricted(media *librespot.Media, country string) bool {

--- a/player/source.go
+++ b/player/source.go
@@ -2,9 +2,10 @@ package player
 
 import (
 	"errors"
-	librespot "github.com/devgianlu/go-librespot"
 	"io"
 	"sync"
+
+	librespot "github.com/devgianlu/go-librespot"
 )
 
 type SwitchingAudioSource struct {

--- a/player/stream.go
+++ b/player/stream.go
@@ -2,6 +2,7 @@ package player
 
 import (
 	"bytes"
+
 	librespot "github.com/devgianlu/go-librespot"
 	metadatapb "github.com/devgianlu/go-librespot/proto/spotify/metadata"
 )

--- a/session/client_token.go
+++ b/session/client_token.go
@@ -3,14 +3,15 @@ package session
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
 	librespot "github.com/devgianlu/go-librespot"
 	pbdata "github.com/devgianlu/go-librespot/proto/spotify/clienttoken/data/v0"
 	pbhttp "github.com/devgianlu/go-librespot/proto/spotify/clienttoken/http/v0"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
-	"io"
-	"net/http"
-	"net/url"
 )
 
 func retrieveClientToken(deviceId string) (string, error) {

--- a/session/oauth2.go
+++ b/session/oauth2.go
@@ -3,9 +3,10 @@ package session
 import (
 	"context"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func NewOAuth2Server(ctx context.Context, callbackPort int) (int, chan string, error) {

--- a/session/session.go
+++ b/session/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+
 	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/ap"
 	"github.com/devgianlu/go-librespot/apresolve"

--- a/spclient/context_resolver.go
+++ b/spclient/context_resolver.go
@@ -3,13 +3,14 @@ package spclient
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
 	librespot "github.com/devgianlu/go-librespot"
 	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
-	"io"
-	"strconv"
-	"strings"
 )
 
 type ContextResolver struct {

--- a/spclient/spclient.go
+++ b/spclient/spclient.go
@@ -5,6 +5,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
 	"github.com/cenkalti/backoff/v4"
 	librespot "github.com/devgianlu/go-librespot"
 	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
@@ -13,10 +18,6 @@ import (
 	playerpb "github.com/devgianlu/go-librespot/proto/spotify/player"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
-	"io"
-	"net/http"
-	"net/url"
-	"strconv"
 )
 
 type Spclient struct {

--- a/tracks/paged_list.go
+++ b/tracks/paged_list.go
@@ -3,10 +3,11 @@ package tracks
 import (
 	"errors"
 	"fmt"
+	"io"
+
 	librespot "github.com/devgianlu/go-librespot"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/rand"
-	"io"
 )
 
 type pagedListItem[T any] struct {

--- a/tracks/paged_list_test.go
+++ b/tracks/paged_list_test.go
@@ -1,10 +1,11 @@
 package tracks
 
 import (
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/exp/rand"
 	"io"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/rand"
 )
 
 type dummyPageResolver struct {

--- a/tracks/tracks.go
+++ b/tracks/tracks.go
@@ -2,6 +2,7 @@ package tracks
 
 import (
 	"fmt"
+
 	librespot "github.com/devgianlu/go-librespot"
 	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
 	"github.com/devgianlu/go-librespot/spclient"

--- a/vorbis/decoder.go
+++ b/vorbis/decoder.go
@@ -3,12 +3,13 @@ package vorbis
 import (
 	"errors"
 	"fmt"
-	librespot "github.com/devgianlu/go-librespot"
-	"github.com/devgianlu/go-librespot/audio"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"strings"
 	"sync"
+
+	librespot "github.com/devgianlu/go-librespot"
+	"github.com/devgianlu/go-librespot/audio"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/xlab/vorbis-go/vorbis"
 )

--- a/zeroconf/zeroconf.go
+++ b/zeroconf/zeroconf.go
@@ -9,14 +9,15 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
 	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/dh"
 	devicespb "github.com/devgianlu/go-librespot/proto/spotify/connectstate/devices"
 	"github.com/grandcat/zeroconf"
 	log "github.com/sirupsen/logrus"
-	"net"
-	"net/http"
-	"sync"
 )
 
 type Zeroconf struct {


### PR DESCRIPTION
I ran `goimports -w .` on the repository to sort all imports in the same way that VSCode does, with the exception of the proto/ directory because those are automatically generated files.

This makes it easier to edit files in VSCode with the default settings, without introducing spurious changes.

I don't know whether this is a change you'd like to have, but it makes things a little bit easier for me :)