### PR TITLE
feat: add Dockerfile for cross-compiling

### DIFF
--- a/build/cross_compile/Dockerfile
+++ b/build/cross_compile/Dockerfile
@@ -1,0 +1,53 @@
+from docker.io/golang:1.22.2-bookworm
+
+# Preparations
+RUN apt-get update && apt-get install -y wget build-essential
+
+
+# Download and extract dependency sources
+RUN cd /tmp && \
+    wget http://www.alsa-project.org/files/pub/lib/alsa-lib-1.2.10.tar.bz2 && \
+    tar -xvf alsa-lib-1.2.10.tar.bz2
+RUN cd /tmp && \
+    wget https://downloads.xiph.org/releases/ogg/libogg-1.3.5.tar.xz && \
+    tar -xvf libogg-1.3.5.tar.xz
+RUN cd /tmp && \
+    wget https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz && \
+    tar -xvf libvorbis-1.3.7.tar.xz
+
+
+ARG TARGET=x86-64-linux-gnu CC=gcc
+
+# Install toolchain for anything besides arm-rpi-linux-gnueabihf
+RUN if [ ${TARGET} != arm-rpi-linux-gnueabihf ]; then \
+        apt-get install -y gcc-${TARGET} ; \
+    fi
+
+# Install custom toolchain for arm-rpi-linux-gnueabihf
+RUN if [ ${TARGET} = arm-rpi-linux-gnueabihf ]; then \
+        cd /tmp && \
+        wget https://github.com/devgianlu/rpi-toolchain/releases/download/v1/arm-rpi-linux-gnueabihf.tar.gz && \
+        tar -C /usr --strip-components=1 -xzf arm-rpi-linux-gnueabihf.tar.gz ; \
+    fi
+
+
+# Compile dependency sources
+RUN cd /tmp/alsa-lib-1.2.10 && \
+    ./configure --enable-shared=yes --enable-static=no --with-pic --host=${TARGET} --prefix=/tmp/deps/${TARGET} && \
+    make && make install
+RUN cd /tmp/libogg-1.3.5 && \
+    ./configure --host=${TARGET} --prefix=/tmp/deps/${TARGET} && \
+    make && make install
+RUN cd /tmp/libvorbis-1.3.7 && \
+    ./configure --host=${TARGET} --prefix=/tmp/deps/${TARGET} && \
+    make && make install
+
+
+WORKDIR /src
+ARG GOARCH=amd64 GOAMD64=v1 GOARM=6 GOOUTSUFFIX=-x86_64
+ENV CGO_ENABLED=1 PKG_CONFIG_PATH=/tmp/deps/${TARGET}/lib/pkgconfig/ CC=${CC} \
+    GOARCH=${GOARCH} GOAMD64=${GOAMD64} GOARM=${GOARM} GOOUTSUFFIX=${GOOUTSUFFIX} \
+    GOCACHE=/src/.gocache/go-build GOMODCACHE=/src/.gocache/mod
+CMD go build \
+    -ldflags="-s -w" \
+    -o ./go-librespot${GOOUTSUFFIX} -a ./cmd/daemon

--- a/build/cross_compile/README.md
+++ b/build/cross_compile/README.md
@@ -1,0 +1,32 @@
+# (Cross-)Compile and Build `go-librespot`
+
+
+## Create Docker image(s) for (cross-)compiling and building `go-librespot`
+
+### Target Linux x86_64
+`docker build -t go-librespot-build-x86_64 .`
+
+### Target Linux on Raspberry Pi 1 / Zero
+`docker build --build-arg TARGET=arm-rpi-linux-gnueabihf --build-arg GOARCH=arm --build-arg CC=arm-rpi-linux-gnueabihf-gcc --build-arg GOOUTSUFFIX=-armv6_rpi -t go-librespot-build-armv6_rpi .`
+
+### Target Linux ARM32 (Raspberry Pi 2 and above)
+`docker build --build-arg TARGET=arm-linux-gnueabihf --build-arg GOARCH=arm --build-arg CC=arm-linux-gnueabihf-gcc --build-arg GOOUTSUFFIX=-armv6 -t go-librespot-build-armv6 .`
+
+### Target Linux ARM64
+`docker build --build-arg TARGET=aarch64-linux-gnu --build-arg GOARCH=arm64 --build-arg CC=aarch64-linux-gnu-gcc --build-arg GOOUTSUFFIX=-arm64 -t go-librespot-build-arm64 .`
+
+
+## Use the image(s) built above to (cross-)compile/build `go-librespot`
+`cd` into the root of the `go-librespot` source code and run on of the following statements.
+
+### Target Linux x86_64
+`docker run -it --rm -v $PWD:/src go-librespot-build-x86_64`
+
+### Target Linux on Raspberry Pi 1 / Zero
+`docker run -it --rm -v $PWD:/src go-librespot-build-armv6_rpi`
+
+### Target Linux ARM32 (Raspberry Pi 2 and above)
+`docker run -it --rm -v $PWD:/src go-librespot-build-armv6`
+
+### Target Linux ARM64
+`docker run -it --rm -v $PWD:/src go-librespot-build-arm64`


### PR DESCRIPTION
It's basically a copy of `.github/workflows/release.yml` in a `Dockerfile` and enables one to cross-build also for other platforms without having to do or wait for a GitHub release.

I was only able to test the results for `x86-64-linux-gnu` and `arm-rpi-linux-gnueabihf` on actual hardware but the other two targets at least compile without errors.