### PR TITLE
fix: don't crash when to-be-prefetched track uri is empty

### DIFF
--- a/cmd/daemon/controls.go
+++ b/cmd/daemon/controls.go
@@ -22,7 +22,14 @@ func (p *AppPlayer) prefetchNext() {
 		return
 	}
 
-	nextId := librespot.SpotifyIdFromUri(next.Uri)
+	// TODO: the same logic is present in ContextTrackToProvidedTrack and should
+	// probably be generalized.
+	var nextId librespot.SpotifyId
+	if next.Uri != "" {
+		nextId = librespot.SpotifyIdFromUri(next.Uri)
+	} else {
+		nextId = librespot.SpotifyIdFromGid(librespot.SpotifyIdTypeTrack, next.Gid)
+	}
 	if p.secondaryStream != nil && p.secondaryStream.Is(nextId) {
 		return
 	}

--- a/ids.go
+++ b/ids.go
@@ -21,6 +21,8 @@ func InferSpotifyIdTypeFromContextUri(uri string) SpotifyIdType {
 }
 
 func ContextTrackToProvidedTrack(typ SpotifyIdType, track *connectpb.ContextTrack, provider string) *connectpb.ProvidedTrack {
+	// TODO: the same logic is present in AppPlayer.prefetchNext and should
+	// probably be generalized.
 	var uri string
 	if len(track.Uri) > 0 {
 		uri = track.Uri


### PR DESCRIPTION
I'm not sure how to trigger this exactly. It happens when playing albums, and maybe has something to do with the web player and/or switching between players. But it does happen sometimes and just crashing isn't great.

I'm sure I've seen this working as intended (fetching the next track from the `Gid` field) but because it's hard to reproduce I'm not sure how to test this further.