### PR TITLE
api: allow changing (not just setting) states

### DIFF
--- a/api-spec.yml
+++ b/api-spec.yml
@@ -125,6 +125,12 @@ paths:
       responses:
         200:
           description: Successful response
+  /player/playpause:
+    post:
+      description: Resume playback when paused, or pause playback when playing
+      responses:
+        200:
+          description: Successful response
   /player/next:
     post:
       description: Skip to next track

--- a/api-spec.yml
+++ b/api-spec.yml
@@ -192,7 +192,10 @@ paths:
                 volume:
                   description: Volume from 0 to max
                   type: number
-                  minimum: 0
+                relative:
+                  description: Whether to change the volume relative to the current volume
+                  type: boolean
+                  default: false
       responses:
         200:
           description: Successful response

--- a/cmd/daemon/api_server.go
+++ b/cmd/daemon/api_server.go
@@ -53,6 +53,7 @@ const (
 	ApiRequestTypeStatus              ApiRequestType = "status"
 	ApiRequestTypeResume              ApiRequestType = "resume"
 	ApiRequestTypePause               ApiRequestType = "pause"
+	ApiRequestTypePlayPause           ApiRequestType = "playpause"
 	ApiRequestTypeSeek                ApiRequestType = "seek"
 	ApiRequestTypePrev                ApiRequestType = "prev"
 	ApiRequestTypeNext                ApiRequestType = "next"
@@ -380,6 +381,14 @@ func (s *ApiServer) serve() {
 		}
 
 		s.handleRequest(ApiRequest{Type: ApiRequestTypePause}, w)
+	})
+	m.HandleFunc("/player/playpause", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		s.handleRequest(ApiRequest{Type: ApiRequestTypePlayPause}, w)
 	})
 	m.HandleFunc("/player/next", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {

--- a/cmd/daemon/api_server.go
+++ b/cmd/daemon/api_server.go
@@ -101,6 +101,11 @@ type ApiRequestDataSeek struct {
 	Relative bool  `json:"relative"`
 }
 
+type ApiRequestDataVolume struct {
+	Volume   int32 `json:"volume"`
+	Relative bool  `json:"relative"`
+}
+
 type ApiRequestDataWebApi struct {
 	Method string
 	Path   string
@@ -429,20 +434,17 @@ func (s *ApiServer) serve() {
 		if r.Method == "GET" {
 			s.handleRequest(ApiRequest{Type: ApiRequestTypeGetVolume}, w)
 		} else if r.Method == "POST" {
-			var data struct {
-				Volume uint32 `json:"volume"`
-			}
+			var data ApiRequestDataVolume
 			if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
-
-			if data.Volume < 0 {
+			if !data.Relative && data.Volume < 0 {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
 
-			s.handleRequest(ApiRequest{Type: ApiRequestTypeSetVolume, Data: data.Volume}, w)
+			s.handleRequest(ApiRequest{Type: ApiRequestTypeSetVolume, Data: data}, w)
 		} else {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}

--- a/cmd/daemon/controls.go
+++ b/cmd/daemon/controls.go
@@ -532,6 +532,12 @@ func (p *AppPlayer) advanceNext(forceNext, drop bool) (bool, error) {
 	return hasNextTrack, nil
 }
 
+// Return the volume as an integer in the range 0..player.MaxStateVolume, as
+// used in the API.
+func (p *AppPlayer) apiVolume() uint32 {
+	return uint32(math.Ceil(float64(p.state.device.Volume*p.app.cfg.VolumeSteps) / player.MaxStateVolume))
+}
+
 func (p *AppPlayer) updateVolume(newVal uint32) {
 	if newVal > player.MaxStateVolume {
 		newVal = player.MaxStateVolume
@@ -555,7 +561,7 @@ func (p *AppPlayer) updateVolume(newVal uint32) {
 	p.app.server.Emit(&ApiEvent{
 		Type: ApiEventTypeVolume,
 		Data: ApiEventDataVolume{
-			Value: uint32(math.Ceil(float64(newVal*p.app.cfg.VolumeSteps) / player.MaxStateVolume)),
+			Value: p.apiVolume(),
 			Max:   p.app.cfg.VolumeSteps,
 		},
 	})

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -420,6 +420,13 @@ func (p *AppPlayer) handleApiRequest(req ApiRequest) (any, error) {
 	case ApiRequestTypePause:
 		_ = p.pause()
 		return nil, nil
+	case ApiRequestTypePlayPause:
+		if p.state.player.IsPaused {
+			_ = p.play()
+		} else {
+			_ = p.pause()
+		}
+		return nil, nil
 	case ApiRequestTypeSeek:
 		data := req.Data.(ApiRequestDataSeek)
 

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -490,8 +490,18 @@ func (p *AppPlayer) handleApiRequest(req ApiRequest) (any, error) {
 			Value: uint32(math.Ceil(float64(p.state.device.Volume*p.app.cfg.VolumeSteps) / player.MaxStateVolume)),
 		}, nil
 	case ApiRequestTypeSetVolume:
-		vol := req.Data.(uint32)
-		p.updateVolume(vol * player.MaxStateVolume / p.app.cfg.VolumeSteps)
+		data := req.Data.(ApiRequestDataVolume)
+
+		var volume int32
+		if data.Relative {
+			volume = int32(math.Ceil(float64(p.state.device.Volume*p.app.cfg.VolumeSteps) / player.MaxStateVolume))
+			volume += data.Volume
+			volume = max(min(volume, int32(p.app.cfg.VolumeSteps)), 0)
+		} else {
+			volume = data.Volume
+		}
+
+		p.updateVolume(uint32(volume) * player.MaxStateVolume / p.app.cfg.VolumeSteps)
 		return nil, nil
 	case ApiRequestTypeSetRepeatingContext:
 		val := req.Data.(bool)

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -6,7 +6,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"math"
 	"strings"
 	"sync"
 	"time"
@@ -399,7 +398,7 @@ func (p *AppPlayer) handleApiRequest(req ApiRequest) (any, error) {
 			DeviceType:     p.app.deviceType.String(),
 			DeviceName:     p.app.cfg.DeviceName,
 			VolumeSteps:    p.app.cfg.VolumeSteps,
-			Volume:         p.state.device.Volume,
+			Volume:         p.apiVolume(),
 			RepeatContext:  p.state.player.Options.RepeatingContext,
 			RepeatTrack:    p.state.player.Options.RepeatingTrack,
 			ShuffleContext: p.state.player.Options.ShufflingContext,
@@ -487,14 +486,14 @@ func (p *AppPlayer) handleApiRequest(req ApiRequest) (any, error) {
 	case ApiRequestTypeGetVolume:
 		return &ApiResponseVolume{
 			Max:   p.app.cfg.VolumeSteps,
-			Value: uint32(math.Ceil(float64(p.state.device.Volume*p.app.cfg.VolumeSteps) / player.MaxStateVolume)),
+			Value: p.apiVolume(),
 		}, nil
 	case ApiRequestTypeSetVolume:
 		data := req.Data.(ApiRequestDataVolume)
 
 		var volume int32
 		if data.Relative {
-			volume = int32(math.Ceil(float64(p.state.device.Volume*p.app.cfg.VolumeSteps) / player.MaxStateVolume))
+			volume = int32(p.apiVolume())
 			volume += data.Volume
 			volume = max(min(volume, int32(p.app.cfg.VolumeSteps)), 0)
 		} else {


### PR DESCRIPTION
This PR adds a play/pause command, and relative volume changes to the API. I plan to use these in Home Assistant through the [RESTful Command](https://www.home-assistant.io/integrations/rest_command/) integration.

Sadly Home Assistant doesn't support custom players yet in which case we could support whatever protocol it uses in go-librespot, so I'll just use REST commands as a poor man's media player in Home Assistant.