### PR TITLE
fix: retry PutConnectState on error, check ContentLength to avoid EOF error

### DIFF
--- a/spclient/spclient.go
+++ b/spclient/spclient.go
@@ -164,15 +164,11 @@ func (c *Spclient) PutConnectState(spotConnId string, reqProto *connectpb.PutSta
 
 		if resp.StatusCode != 200 {
 			var putError putStateError
-			if resp.ContentLength <= 0 {
-				log.Debugf("failure to decode response.Body, ContentLength was: %d", resp.ContentLength)
-				return nil, fmt.Errorf("failure to decode response.Body, ContentLength was: %d", resp.ContentLength)
-			}
 			if err := json.NewDecoder(resp.Body).Decode(&putError); err != nil {
-				log.Debugf("failed reading error response %s, retrying in 1 second", err)
+				log.Debugf("failed reading error response %s", err)
 				return nil, fmt.Errorf("failed reading error response: %w", err)
 			}
-			log.Debugf("put state request failed with status %d: %s, retrying in 1 second", resp.StatusCode, putError.Message)
+			log.Debugf("put state request failed with status %d: %s", resp.StatusCode, putError.Message)
 			return nil, fmt.Errorf("put state request failed with status %d: %s", resp.StatusCode, putError.Message)
 		} else {
 			log.Debugf("put connect state because %s", reqProto.PutStateReason)

--- a/spclient/spclient.go
+++ b/spclient/spclient.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	librespot "github.com/devgianlu/go-librespot"
@@ -145,34 +146,43 @@ func (c *Spclient) PutConnectState(spotConnId string, reqProto *connectpb.PutSta
 	if err != nil {
 		return fmt.Errorf("failed marshalling PutStateRequest: %w", err)
 	}
+	_, err = backoff.RetryWithData(func() (*http.Response, error) {
+		resp, err := c.request(
+			"PUT",
+			fmt.Sprintf("/connect-state/v1/devices/%s", c.deviceId),
+			nil,
+			http.Header{
+				"X-Spotify-Connection-Id": []string{spotConnId},
+				"Content-Type":            []string{"application/x-protobuf"},
+			},
+			reqBody,
+		)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
 
-	resp, err := c.request(
-		"PUT",
-		fmt.Sprintf("/connect-state/v1/devices/%s", c.deviceId),
-		nil,
-		http.Header{
-			"X-Spotify-Connection-Id": []string{spotConnId},
-			"Content-Type":            []string{"application/x-protobuf"},
-		},
-		reqBody,
-	)
+		if resp.StatusCode != 200 {
+			var putError putStateError
+			if resp.ContentLength <= 0 {
+				log.Debugf("failure to decode response.Body, ContentLength was: %d", resp.ContentLength)
+				return nil, fmt.Errorf("failure to decode response.Body, ContentLength was: %d", resp.ContentLength)
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&putError); err != nil {
+				log.Debugf("failed reading error response %s, retrying in 1 second", err)
+				return nil, fmt.Errorf("failed reading error response: %w", err)
+			}
+			log.Debugf("put state request failed with status %d: %s, retrying in 1 second", resp.StatusCode, putError.Message)
+			return nil, fmt.Errorf("put state request failed with status %d: %s", resp.StatusCode, putError.Message)
+		} else {
+			log.Debugf("put connect state because %s", reqProto.PutStateReason)
+			return resp, nil
+		}
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 2))
 	if err != nil {
 		return err
 	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != 200 {
-		var putError putStateError
-		if err := json.NewDecoder(resp.Body).Decode(&putError); err != nil {
-			return fmt.Errorf("failed reading error response: %w", err)
-		}
-
-		return fmt.Errorf("put state request failed with status %d: %s", resp.StatusCode, putError.Message)
-	} else {
-		log.Debugf("put connect state because %s", reqProto.PutStateReason)
-		return nil
-	}
+	return nil
 }
 
 func (c *Spclient) ResolveStorageInteractive(fileId []byte, prefetch bool) (*storagepb.StorageResolveResponse, error) {


### PR DESCRIPTION
I was getting 500 status with empty body randomly throughout the day when PutConnectState was called.
Have tested for a day or so and I am not getting EOF errors anymore.

Commit does:
Retrying the request (not sure how important that method is for the app to run properly) and checking ContentLength so we are not getting EOF errors during decoding JSON.