### PR TITLE
fix: update PlaybackSpeed when changing the IsPaused flag

### DIFF
--- a/cmd/daemon/controls.go
+++ b/cmd/daemon/controls.go
@@ -65,7 +65,7 @@ func (p *AppPlayer) handlePlayerEvent(ev *player.Event) {
 	switch ev.Type {
 	case player.EventTypePlaying:
 		p.state.player.IsPlaying = true
-		p.state.player.IsPaused = false
+		p.state.setPaused(false)
 		p.state.player.IsBuffering = false
 		p.updateState()
 
@@ -78,7 +78,7 @@ func (p *AppPlayer) handlePlayerEvent(ev *player.Event) {
 		})
 	case player.EventTypePaused:
 		p.state.player.IsPlaying = true
-		p.state.player.IsPaused = true
+		p.state.setPaused(true)
 		p.state.player.IsBuffering = false
 		p.updateState()
 
@@ -132,7 +132,7 @@ func (p *AppPlayer) loadContext(ctx *connectpb.Context, skipTo skipToFunc, pause
 		return fmt.Errorf("failed creating track list: %w", err)
 	}
 
-	p.state.player.IsPaused = paused
+	p.state.setPaused(paused)
 
 	p.state.player.ContextUri = ctx.Uri
 	p.state.player.ContextUrl = ctx.Url
@@ -199,7 +199,7 @@ func (p *AppPlayer) loadCurrentTrack(paused, drop bool) error {
 
 	p.state.player.IsPlaying = true
 	p.state.player.IsBuffering = true
-	p.state.player.IsPaused = paused
+	p.state.setPaused(paused)
 	p.updateState()
 
 	p.app.server.Emit(&ApiEvent{
@@ -348,7 +348,7 @@ func (p *AppPlayer) play() error {
 
 	p.state.player.Timestamp = time.Now().UnixMilli()
 	p.state.player.PositionAsOfTimestamp = streamPos
-	p.state.player.IsPaused = false
+	p.state.setPaused(false)
 	p.updateState()
 	p.schedulePrefetchNext()
 
@@ -367,7 +367,7 @@ func (p *AppPlayer) pause() error {
 
 	p.state.player.Timestamp = time.Now().UnixMilli()
 	p.state.player.PositionAsOfTimestamp = streamPos
-	p.state.player.IsPaused = true
+	p.state.setPaused(true)
 	p.updateState()
 	p.schedulePrefetchNext()
 

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -151,21 +151,16 @@ func (p *AppPlayer) handlePlayerCommand(req dealer.RequestPayload) error {
 		p.state.setActive(true)
 		p.state.player.IsPlaying = false
 		p.state.player.IsBuffering = false
-		p.state.player.IsPaused = false
 
 		// options
 		p.state.player.Options = transferState.Options
 
 		// playback
+		// Note: this sets playback speed to 0 or 1 because that's all we're
+		// capable of, depending on whether the playback is paused or not.
 		p.state.player.Timestamp = transferState.Playback.Timestamp
 		p.state.player.PositionAsOfTimestamp = int64(transferState.Playback.PositionAsOfTimestamp)
-		p.state.player.IsPaused = transferState.Playback.IsPaused
-
-		if playbackSpeed := transferState.Playback.PlaybackSpeed; playbackSpeed != 0 {
-			p.state.player.PlaybackSpeed = playbackSpeed
-		} else {
-			p.state.player.PlaybackSpeed = 1
-		}
+		p.state.setPaused(transferState.Playback.IsPaused)
 
 		// current session
 		p.state.player.PlayOrigin = transferState.CurrentSession.PlayOrigin
@@ -452,7 +447,7 @@ func (p *AppPlayer) handleApiRequest(req ApiRequest) (any, error) {
 		}
 
 		p.state.setActive(true)
-		p.state.player.PlaybackSpeed = 1
+		p.state.setPaused(data.Paused)
 		p.state.player.Suppressions = &connectpb.Suppressions{}
 		p.state.player.PlayOrigin = &connectpb.PlayOrigin{
 			FeatureIdentifier: "go-librespot",

--- a/cmd/daemon/state.go
+++ b/cmd/daemon/state.go
@@ -23,6 +23,18 @@ type State struct {
 	lastCommand *dealer.RequestPayload
 }
 
+// Set the IsPaused flag, and also the PlaybackSpeed as well.
+// PlaybackSpeed must be 0 when paused, or Spotify Android will have subtle
+// bugs.
+func (s *State) setPaused(val bool) {
+	s.player.IsPaused = val
+	if val {
+		s.player.PlaybackSpeed = 0
+	} else {
+		s.player.PlaybackSpeed = 1
+	}
+}
+
 func (s *State) setActive(val bool) {
 	if val {
 		if s.active {


### PR DESCRIPTION
The PlaybackSpeed field must be set to 0 when paused. Otherwise Spotify Android will correctly show the stream as paused but will still move the playback position when redrawing the UI (and for a very short time when resuming playback).

Fixes #104 