### PR TITLE
fix: default API to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ website at `http://129.168.1.1:8080`, the following configuration can be used:
 ```yaml
 server:
   enabled: true
+  address: "" # allow connections from anywhere (default is localhost only)
   port: 3678
   allow_origin: 'http://129.168.1.1:8080'
 ```

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -409,6 +409,7 @@ func loadConfig(cfg *Config) error {
 		"volume_steps":       100,
 		"initial_volume":     100,
 		"credentials.type":   "zeroconf",
+		"server.address":     "localhost",
 	}, "."), nil)
 
 	// load file configuration (if available)

--- a/config_schema.json
+++ b/config_schema.json
@@ -86,7 +86,7 @@
             "address": {
               "type": "string",
               "description": "Which address to bind for the API server",
-              "default": ""
+              "default": "localhost"
             },
             "port": {
               "type": "integer",


### PR DESCRIPTION
The previous default was to bind to 0.0.0.0 and allow connections from anywhere. I think this is an insecure default, the default should be restricted.

To restore the previous behavior, use:

```yaml
server:
  address: ""
```

For example, I'm using the API from Home Assistant running on the same Raspberry Pi. There is no reason for the API to be exposed on my local network. And generally it's a good idea to have safe default values (and require users to opt-in to less safe options).

(Not sure whether this counts as a fix or a feature, but I guess it fixes potential unsafe configurations, so...)