### PR TITLE
fix: do not panic when the URI of the next track is unset

### DIFF
--- a/cmd/daemon/controls.go
+++ b/cmd/daemon/controls.go
@@ -22,6 +22,14 @@ func (p *AppPlayer) prefetchNext() {
 		return
 	}
 
+	if next.Uri == "" {
+		// It should be implemented some day (the ContextTrack has enough
+		// information to infer the track Uri) but it's hard to reproduce this
+		// issue.
+		log.Warn("cannot prefetch next track because the uri field is empty")
+		return
+	}
+
 	nextId := librespot.SpotifyIdFromUri(next.Uri)
 	if p.secondaryStream != nil && p.secondaryStream.Is(nextId) {
 		return


### PR DESCRIPTION
This should be implemented some day, but until it is this at least keeps the player from crashing.

This is a more conservative alternative to https://github.com/devgianlu/go-librespot/pull/98.