### PR TITLE
fix: don't seek to the start when swiping right

### DIFF
--- a/cmd/daemon/controls.go
+++ b/cmd/daemon/controls.go
@@ -416,8 +416,8 @@ func (p *AppPlayer) seek(position int64) error {
 	return nil
 }
 
-func (p *AppPlayer) skipPrev() error {
-	if p.player.PositionMs() > 3000 {
+func (p *AppPlayer) skipPrev(allowSeeking bool) error {
+	if allowSeeking && p.player.PositionMs() > 3000 {
 		return p.seek(0)
 	}
 

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -277,7 +277,7 @@ func (p *AppPlayer) handlePlayerCommand(req dealer.RequestPayload) error {
 
 		return nil
 	case "skip_prev":
-		return p.skipPrev()
+		return p.skipPrev(req.Command.Options.AllowSeeking)
 	case "skip_next":
 		if req.Command.Track != nil {
 			contextSpotType := librespot.InferSpotifyIdTypeFromContextUri(p.state.player.ContextUri)
@@ -441,7 +441,7 @@ func (p *AppPlayer) handleApiRequest(req ApiRequest) (any, error) {
 		_ = p.seek(position)
 		return nil, nil
 	case ApiRequestTypePrev:
-		_ = p.skipPrev()
+		_ = p.skipPrev(true)
 		return nil, nil
 	case ApiRequestTypeNext:
 		_ = p.skipNext()

--- a/dealer/recv.go
+++ b/dealer/recv.go
@@ -69,6 +69,7 @@ type RequestPayload struct {
 			RestorePosition     string `json:"restore_position"`
 			RestoreTrack        string `json:"restore_track"`
 			AlwaysPlaySomething bool   `json:"always_play_something"`
+			AllowSeeking        bool   `json:"allow_seeking"`
 			SkipTo              struct {
 				TrackUid   string `json:"track_uid"`
 				TrackUri   string `json:"track_uri"`


### PR DESCRIPTION
The API has an extra parameter `allow_seeking` that indicates whether the seek left is due to pressing the "prev" button, or because the album is swiped right to go to the previous track immediately.

This patch adds support for this feature.

There's still one issue however: when going to the previous song, the player will for a short time show the first track in an album. ~Not sure why, I suspect go-librespot doesn't send the whole queue (so the player doesn't know there are other tracks in the album).~ see https://github.com/devgianlu/go-librespot/pull/113 for a fix to this bug.