### PR TITLE
fix: put previous tracks in the right order

### DIFF
--- a/tracks/tracks.go
+++ b/tracks/tracks.go
@@ -2,6 +2,7 @@ package tracks
 
 import (
 	"fmt"
+	"slices"
 
 	librespot "github.com/devgianlu/go-librespot"
 	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
@@ -85,6 +86,9 @@ func (tl *List) PrevTracks() []*connectpb.ProvidedTrack {
 	if err := iter.error(); err != nil {
 		log.WithError(err).Error("failed fetching prev tracks")
 	}
+
+	// Tracks were added in reverse order. Fix this by reversing them again.
+	slices.Reverse(tracks)
 
 	return tracks
 }


### PR DESCRIPTION
These tracks aren't directly visible, but they are visible (for a short bit) when pressing the 'prev' button.

Previously this would always show the first track in an album, which is incorrect. This fix makes sure that 'prev' actually shows the previous track.

Perhaps `slices.Reverse` is not the right way to do this, please let me know if there's a better way.