### PR TITLE
fix: assign UIDs to newly added tracks

### DIFF
--- a/cmd/daemon/controls.go
+++ b/cmd/daemon/controls.go
@@ -321,6 +321,12 @@ func (p *AppPlayer) addToQueue(track *connectpb.ContextTrack) {
 		return
 	}
 
+	if track.Uid == "" {
+		// The uid always seems unset, so we have to set one manually.
+		p.state.queueID++
+		track.Uid = fmt.Sprintf("q%d", p.state.queueID)
+	}
+
 	p.state.tracks.AddToQueue(track)
 	p.state.player.PrevTracks = p.state.tracks.PrevTracks()
 	p.state.player.NextTracks = p.state.tracks.NextTracks()

--- a/cmd/daemon/state.go
+++ b/cmd/daemon/state.go
@@ -18,7 +18,8 @@ type State struct {
 	device *connectpb.DeviceInfo
 	player *connectpb.PlayerState
 
-	tracks *tracks.List
+	tracks  *tracks.List
+	queueID uint64
 
 	lastCommand           *dealer.RequestPayload
 	lastTransferTimestamp int64


### PR DESCRIPTION
This fixes https://github.com/devgianlu/go-librespot/issues/73 and might help with https://github.com/devgianlu/go-librespot/issues/54.