### PR TITLE
fix: don't try to seek to the start of the song when starting from there

### DIFF
--- a/player/player.go
+++ b/player/player.go
@@ -430,8 +430,14 @@ func (p *Player) NewStream(spotId librespot.SpotifyId, bitrate int, mediaPositio
 		return nil, fmt.Errorf("unsupported channels: %d", stream.Channels)
 	}
 
-	if err := stream.SetPositionMs(max(0, min(mediaPosition, int64(media.Duration())))); err != nil {
-		return nil, fmt.Errorf("failed seeking stream: %w", err)
+	// Seek to the correct position as long as it isn't 0.
+	// Seeking to position 0 right after starting would cause a slight stutter
+	// when starting to play a track.
+	// TODO: don't start playing anything until after this seek.
+	if mediaPosition != 0 {
+		if err := stream.SetPositionMs(max(0, min(mediaPosition, int64(media.Duration())))); err != nil {
+			return nil, fmt.Errorf("failed seeking stream: %w", err)
+		}
 	}
 
 	return &Stream{Source: stream, Media: media, File: file}, nil


### PR DESCRIPTION
Apparently a bit of the song has already been decoded before the seek. When seeking after starting the vorbis decode, this causes the song to revert to time 0 causing a slight stutter.

The stutter is presumably still there when an actual seek is needed. But that's probably a less common case. A real fix would be to only start decoding after the seek (which doesn't seem to be the case here).

---

I'm not very happy with this fix. I feel like the real issue is in the vorbis decoder, which apparently already starts decoding in `vorbis.New`. But at least it works around a common case.

fixes #115 