### PR TITLE
feat: don't seek when it's not needed

### DIFF
--- a/player/player.go
+++ b/player/player.go
@@ -430,8 +430,11 @@ func (p *Player) NewStream(spotId librespot.SpotifyId, bitrate int, mediaPositio
 		return nil, fmt.Errorf("unsupported channels: %d", stream.Channels)
 	}
 
-	if err := stream.SetPositionMs(max(0, min(mediaPosition, int64(media.Duration())))); err != nil {
-		return nil, fmt.Errorf("failed seeking stream: %w", err)
+	// Seek to the correct position if needed.
+	if mediaPosition > 0 {
+		if err := stream.SetPositionMs(max(0, min(mediaPosition, int64(media.Duration())))); err != nil {
+			return nil, fmt.Errorf("failed seeking stream: %w", err)
+		}
 	}
 
 	return &Stream{Source: stream, Media: media, File: file}, nil


### PR DESCRIPTION
This seek takes around 0.5-1ms (when seeking to position 0) on a Raspberry Pi 3 which isn't much, but it's totally unnecessary in most cases so can be skipped.

This is basically the same as #116 but now as a very small performance improvement.