### PR TITLE
Fix play/pause

### DIFF
--- a/output/driver-alsa.go
+++ b/output/driver-alsa.go
@@ -182,8 +182,16 @@ func (out *alsaOutput) setupPcm() error {
 	// (Pause() or Close()) or there is an error.
 	pcmHandle := out.pcmHandle
 	go func() {
-		out.err <- out.outputLoop(pcmHandle)
-		_ = out.Close()
+		err := out.outputLoop(pcmHandle)
+		if out.pcmHandle != nil {
+			_ = C.snd_pcm_close(out.pcmHandle)
+			out.pcmHandle = nil
+		}
+
+		if err != nil {
+			_ = out.Close()
+			out.err <- err
+		}
 	}()
 
 	return nil


### PR DESCRIPTION
If the ALSA output loop exists with an EOF or an error the PCM handle will be left dangling. This implies that `Resume()` will not spin up a new output loop and nothing will be actually played.

I don't feel like this is the best fix, but it seems to work. @aykevl Can you have a look, what do you think would be the best approach here?

Fixes #135 