### PR TITLE
fix: fix fast relative volume updates

### DIFF
--- a/cmd/daemon/controls.go
+++ b/cmd/daemon/controls.go
@@ -601,14 +601,7 @@ func (p *AppPlayer) updateVolume(newVal uint32) {
 // Send notification that the volume changed.
 // The original change can come from anywhere: from Spotify Connect, from the
 // REST API, or from a volume mixer.
-func (p *AppPlayer) volumeUpdated(newVal uint32) {
-	// skip volume update
-	if newVal == p.state.device.Volume {
-		return
-	}
-
-	p.state.device.Volume = newVal
-
+func (p *AppPlayer) volumeUpdated() {
 	if err := p.putConnectState(connectpb.PutStateReason_VOLUME_CHANGED); err != nil {
 		log.WithError(err).Error("failed put state after volume change")
 	}

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -552,7 +552,6 @@ func (p *AppPlayer) Run(apiRecv <-chan ApiRequest) {
 	reqRecv := p.sess.Dealer().ReceiveRequest("hm://connect-state/v1/player/command")
 	playerRecv := p.player.Receive()
 
-	var updatedVolume float32
 	volumeTimer := time.NewTimer(time.Minute)
 	volumeTimer.Stop() // don't emit a volume change event at start
 
@@ -588,11 +587,11 @@ func (p *AppPlayer) Run(apiRecv <-chan ApiRequest) {
 			// limit them (otherwise we get HTTP error 429: Too many requests
 			// for user). Sending the new value after 1 second of no updates
 			// matches the Spotify Web Player.
-			updatedVolume = volume
+			p.state.device.Volume = uint32(volume * player.MaxStateVolume)
 			volumeTimer.Reset(time.Second)
 		case <-volumeTimer.C:
 			// We've gone 1 second without update, send the new value now.
-			p.volumeUpdated(uint32(updatedVolume * player.MaxStateVolume))
+			p.volumeUpdated()
 		}
 	}
 }


### PR DESCRIPTION
Relative volume changes would use old values, not the new value set by a volume change in the last second. To fix this, update the player state immediately and only delay sending the update (instead of also delaying the update to the player state).

This could mean that another change (such as play/pause) would send an earlier volume update, but I don't think that's a problem. We'll send a PutStateReason_VOLUME_CHANGED anyway after a second.

Fixes https://github.com/devgianlu/go-librespot/issues/141

This is an alternative to #142 