### PR TITLE
feat: extract commit hash from build info

### DIFF
--- a/version.go
+++ b/version.go
@@ -3,15 +3,30 @@ package go_librespot
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 	"strings"
 )
 
 var commit, version string
 
+// Extract and return the commit hash stored in the binary, if available.
+func commitHash() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				return setting.Value
+			}
+		}
+	}
+	return ""
+}
+
 func VersionNumberString() string {
 	if len(version) > 0 {
 		return strings.TrimPrefix(version, "v")
 	} else if len(commit) >= 8 {
+		return commit[:8]
+	} else if commit := commitHash(); len(commit) >= 8 {
 		return commit[:8]
 	} else {
 		return "dev"
@@ -21,6 +36,8 @@ func VersionNumberString() string {
 func SpotifyLikeClientVersion() string {
 	if len(version) > 0 {
 		if len(commit) >= 8 {
+			return fmt.Sprintf("%s.g%s", version, commit[:8])
+		} else if commit := commitHash(); len(commit) >= 8 {
 			return fmt.Sprintf("%s.g%s", version, commit[:8])
 		} else {
 			return version


### PR DESCRIPTION
The Go toolchain stores the git commit hash in the binary, which can then be extracted using `debug.ReadBuildInfo`. The advantage is that the commit hash is present even on development builds (`go build` etc), and it simplifies CI _slightly_.