### PR TITLE
Add config option to use album gain instead of track gain

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -139,6 +139,7 @@ func (app *App) newAppPlayer(ctx context.Context, creds any) (_ *AppPlayer, err 
 		Log:      app.log,
 
 		NormalisationEnabled: !app.cfg.NormalisationDisabled,
+		NormalisationUseAlbumGain: app.cfg.NormalisationUseAlbumGain,
 		NormalisationPregain: app.cfg.NormalisationPregain,
 
 		CountryCode: appPlayer.countryCode,
@@ -376,6 +377,7 @@ type Config struct {
 	VolumeSteps                   uint32    `koanf:"volume_steps"`
 	InitialVolume                 uint32    `koanf:"initial_volume"`
 	NormalisationDisabled         bool      `koanf:"normalisation_disabled"`
+	NormalisationUseAlbumGain     bool	`koanf:"normalisation_use_album_gain"`
 	NormalisationPregain          float32   `koanf:"normalisation_pregain"`
 	ExternalVolume                bool      `koanf:"external_volume"`
 	ZeroconfEnabled               bool      `koanf:"zeroconf_enabled"`

--- a/config_schema.json
+++ b/config_schema.json
@@ -237,6 +237,11 @@
           "description": "Whether track/album normalisation should be disabled",
           "default": false
         },
+        "normalisation_use_album_gain": {
+          "type": "boolean",
+          "description": "Whether album gain should be used instead of track gain for normalisation",
+          "default": false
+        },
         "normalisation_pregain": {
           "type": "number",
           "description": "The normalisation pregain to apply to track/album normalisation factors",


### PR DESCRIPTION
librespot (Rust) has an option for it, the original client uses album gain automatically if playing from album.
No volume jumps between tracks when playing a live album.