### PR TITLE
bugfix: fix double unlock of mutex in dealer recvloop

### DIFF
--- a/dealer/dealer.go
+++ b/dealer/dealer.go
@@ -240,11 +240,12 @@ loop:
 
 			// something went very wrong, give up
 			d.Close()
-		}
-		d.connMu.Unlock()
+		} else {
+			d.connMu.Unlock()
 
-		// reconnection was successful, do not close receivers
-		return
+			// reconnection was successful, do not close receivers
+			return
+		}
 	}
 
 	d.requestReceiversLock.RLock()


### PR DESCRIPTION
On error on backoff retry an error message is logged and the mutex unlocked. It is unlocked again outside the error handling and the loop is not stopped (if the unlock wouldn't panic). Fix this by correctly terminating the loop / cleaning up.

Fixes this:
librespot-go-1  | time="2025-04-21T05:15:11Z" level=error msg="failed reconnecting dealer" error="failed obtaining dealer access token: failed renewing login5 access token: failed authenticating with login5: UNKNOWN_ERROR"
librespot-go-1  | fatal error: sync: Unlock of unlocked RWMutex
librespot-go-1  | 
librespot-go-1  | goroutine 20295860 [running]:
librespot-go-1  | sync.fatal({0xb0da65?, 0x2e28ae00000003?})
librespot-go-1  |       /usr/lib/go/src/runtime/panic.go:1007 +0x20
librespot-go-1  | sync.(*RWMutex).Unlock(0x40002be858)
librespot-go-1  |       /usr/lib/go/src/sync/rwmutex.go:208 +0x74
librespot-go-1  | github.com/devgianlu/go-librespot/dealer.(*Dealer).recvLoop(0x40002be7e0)
librespot-go-1  |       /src/librespot/dealer/dealer.go:244 +0x66c
librespot-go-1  | created by github.com/devgianlu/go-librespot/dealer.(*Dealer).reconnect in goroutine 15025033
librespot-go-1  |       /src/librespot/dealer/dealer.go:295 +0x158
