### PR TITLE
chore: add missing websocket field

### DIFF
--- a/API.md
+++ b/API.md
@@ -25,6 +25,7 @@ The websocket endpoint is available at `/events`. The following events are emitt
     - `play_origin`: Who started the playback
 - `playing`: The current track is playing
     - `uri`: The track URI
+    - `resume`: Was this resumed from paused playback?
     - `play_origin`: Who started the playback
 - `not_playing`: The current track has finished playing
     - `uri`: The track URI


### PR DESCRIPTION
I noticed a missing field in the docs today when some of my go-librespot websocket parsing code was failing to handle a playing websocket event. I hope this helps!