### PR TITLE
Docker: multithreaded dependency build

### DIFF
--- a/CROSS_COMPILE.md
+++ b/CROSS_COMPILE.md
@@ -78,5 +78,5 @@ docker run --rm -u $(id -u):$(id -g) -v $PWD:/src -e GOOUTSUFFIX=-armv6 go-libre
 ### Target Linux ARM64
 
 ```bash
-docker run --rm -u $(id -u):$(id -g) -v $PWD:/src g-e GOOUTSUFFIX=-arm64 go-librespot-build-arm64
+docker run --rm -u $(id -u):$(id -g) -v $PWD:/src -e GOOUTSUFFIX=-arm64 go-librespot-build-arm64
 ```

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -36,13 +36,13 @@ RUN if [ ${TARGET} = arm-rpi-linux-gnueabihf ]; then \
 # Compile dependency sources
 RUN cd /tmp/alsa-lib-1.2.10 && \
     ./configure --enable-shared=yes --enable-static=no --with-pic --host=${TARGET} --prefix=/tmp/deps/${TARGET} && \
-    make && make install
+    make -j $(nproc) && make install
 RUN cd /tmp/libogg-1.3.5 && \
     ./configure --host=${TARGET} --prefix=/tmp/deps/${TARGET} && \
-    make && make install
+    make -j $(nproc) && make install
 RUN cd /tmp/libvorbis-1.3.7 && \
     ./configure --host=${TARGET} --prefix=/tmp/deps/${TARGET} && \
-    make && make install
+    make -j $(nproc) && make install
 
 # Golang arguments
 ARG GOARCH


### PR DESCRIPTION
Was crosscompiling go-librespot and noticed that it was very slow compiling ALSA. This fixes that by making it use all available cores. Also noticed a typo in the arm64 crosscompile documentation which caused a failure running the go compile command in docker.

Not sure where the linebreak fixes at the end of the files come from.... Never had that on other projects. I'll try to check if it's somehow not using `\n`