### PR TITLE
Add metadata to fifo pipe output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /lockfile
 
 /dist
+/daemon
+/go-librespot

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -15,6 +15,7 @@ import (
 	librespot "github.com/devgianlu/go-librespot"
 
 	"github.com/devgianlu/go-librespot/apresolve"
+	"github.com/devgianlu/go-librespot/metadata"
 	"github.com/devgianlu/go-librespot/player"
 	devicespb "github.com/devgianlu/go-librespot/proto/spotify/connectstate/devices"
 	"github.com/devgianlu/go-librespot/session"
@@ -115,6 +116,13 @@ func (app *App) newAppPlayer(ctx context.Context, creds any) (_ *AppPlayer, err 
 		volumeUpdate: make(chan float32, 1),
 	}
 
+	appPlayer.metadataPlayer = metadata.NewPlayerMetadata(app.log, metadata.MetadataPipeConfig{
+		Enabled:    app.cfg.MetadataPipe.Enabled,
+		Path:       app.cfg.MetadataPipe.Path,
+		Format:     app.cfg.MetadataPipe.Format,
+		BufferSize: app.cfg.MetadataPipe.BufferSize,
+	})
+
 	// start a dummy timer for prefetching next media
 	appPlayer.prefetchTimer = time.AfterFunc(time.Duration(math.MaxInt64), appPlayer.prefetchNext)
 
@@ -158,9 +166,14 @@ func (app *App) newAppPlayer(ctx context.Context, creds any) (_ *AppPlayer, err 
 
 		AudioOutputPipe:       app.cfg.AudioOutputPipe,
 		AudioOutputPipeFormat: app.cfg.AudioOutputPipeFormat,
+		MetadataCallback:      appPlayer, // AppPlayer implements MetadataCallback
 	},
 	); err != nil {
 		return nil, fmt.Errorf("failed initializing player: %w", err)
+	}
+
+	if err := appPlayer.metadataPlayer.Start(); err != nil {
+		app.log.WithError(err).Errorf("failed to start metadata system")
 	}
 
 	return appPlayer, nil
@@ -412,6 +425,12 @@ type Config struct {
 			PersistCredentials bool `koanf:"persist_credentials"`
 		} `koanf:"zeroconf"`
 	} `koanf:"credentials"`
+	MetadataPipe struct {
+		Enabled    bool   `koanf:"enabled"`
+		Path       string `koanf:"path"`
+		Format     string `koanf:"format"`
+		BufferSize int    `koanf:"buffer_size"`
+	} `koanf:"metadata_pipe"`
 }
 
 func loadConfig(cfg *Config) error {
@@ -465,8 +484,12 @@ func loadConfig(cfg *Config) error {
 		"volume_steps":   100,
 		"initial_volume": 100,
 
-		"credentials.type": "zeroconf",
-		"server.address":   "localhost",
+		"credentials.type":          "zeroconf",
+		"server.address":            "localhost",
+		"metadata_pipe.enabled":     false,
+		"metadata_pipe.path":        "/tmp/go-librespot-metadata",
+		"metadata_pipe.format":      "dacp",
+		"metadata_pipe.buffer_size": 100,
 	}, "."), nil)
 
 	// load file configuration (if available)

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -624,9 +624,10 @@ func (p *AppPlayer) Run(ctx context.Context, apiRecv <-chan ApiRequest) {
 	}
 }
 
-func (p *AppPlayer) UpdateTrack(title, artist, album, trackID string, duration time.Duration, playing bool) {
+// Update AppPlayer's UpdateTrack method:
+func (p *AppPlayer) UpdateTrack(title, artist, album, trackID string, duration time.Duration, playing bool, artworkURL string, artworkData []byte) {
 	if p.metadataPlayer != nil {
-		p.metadataPlayer.UpdateTrack(title, artist, album, trackID, duration, playing)
+		p.metadataPlayer.UpdateTrack(title, artist, album, trackID, duration, playing, artworkURL, artworkData)
 	}
 }
 

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -20,6 +20,7 @@ import (
 	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/ap"
 	"github.com/devgianlu/go-librespot/dealer"
+	"github.com/devgianlu/go-librespot/metadata"
 	"github.com/devgianlu/go-librespot/player"
 	connectpb "github.com/devgianlu/go-librespot/proto/spotify/connectstate"
 	"github.com/devgianlu/go-librespot/session"
@@ -46,7 +47,8 @@ type AppPlayer struct {
 	primaryStream   *player.Stream
 	secondaryStream *player.Stream
 
-	prefetchTimer *time.Timer
+	prefetchTimer  *time.Timer
+	metadataPlayer *metadata.PlayerMetadata
 }
 
 func (p *AppPlayer) handleAccesspointPacket(pktType ap.PacketType, payload []byte) error {
@@ -619,5 +621,29 @@ func (p *AppPlayer) Run(ctx context.Context, apiRecv <-chan ApiRequest) {
 			// We've gone some time without update, send the new value now.
 			p.volumeUpdated(ctx)
 		}
+	}
+}
+
+func (p *AppPlayer) UpdateTrack(title, artist, album, trackID string, duration time.Duration, playing bool) {
+	if p.metadataPlayer != nil {
+		p.metadataPlayer.UpdateTrack(title, artist, album, trackID, duration, playing)
+	}
+}
+
+func (p *AppPlayer) UpdatePosition(position time.Duration) {
+	if p.metadataPlayer != nil {
+		p.metadataPlayer.UpdatePosition(position)
+	}
+}
+
+func (p *AppPlayer) UpdateVolume(volume int) {
+	if p.metadataPlayer != nil {
+		p.metadataPlayer.UpdateVolume(volume)
+	}
+}
+
+func (p *AppPlayer) UpdatePlayingState(playing bool) {
+	if p.metadataPlayer != nil {
+		p.metadataPlayer.UpdatePlayingState(playing)
 	}
 }

--- a/config_schema.json
+++ b/config_schema.json
@@ -256,6 +256,35 @@
           "type": "boolean",
           "description": "Whether autoplay of more songs should be disabled",
           "default": false
+        },
+        "metadata_pipe": {
+          "type": "object",
+          "description": "Metadata pipe configuration for DACP/forked-daapd integration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable metadata pipe output"
+            },
+            "path": {
+              "type": "string",
+              "default": "/tmp/go-librespot-metadata",
+              "description": "Path to the metadata FIFO pipe"
+            },
+            "format": {
+              "type": "string",
+              "enum": ["dacp", "json", "xml"],
+              "default": "dacp",
+              "description": "Output format for metadata (dacp for forked-daapd, json for custom applications)"
+            },
+            "buffer_size": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 100,
+              "description": "Size of the metadata buffer"
+            }
+          }
         }
       },
       "required": [

--- a/metadata/fifo.go
+++ b/metadata/fifo.go
@@ -1,0 +1,206 @@
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+
+	librespot "github.com/devgianlu/go-librespot"
+)
+
+// FIFOManager manages the metadata FIFO pipe
+type FIFOManager struct {
+	log        librespot.Logger
+	path       string
+	format     string
+	bufferSize int
+
+	pipe   *os.File
+	mutex  sync.RWMutex
+	closed bool
+	buffer chan []byte
+	stopCh chan struct{}
+
+	// Metrics
+	writeCount int64
+	errorCount int64
+	dropCount  int64
+}
+
+// NewFIFOManager creates a new FIFO manager
+func NewFIFOManager(log librespot.Logger, path, format string, bufferSize int) *FIFOManager {
+	return &FIFOManager{
+		log:        log,
+		path:       path,
+		format:     format,
+		bufferSize: bufferSize,
+		buffer:     make(chan []byte, bufferSize),
+		stopCh:     make(chan struct{}),
+	}
+}
+
+// Start initializes and starts the FIFO manager
+func (fm *FIFOManager) Start() error {
+	// Create named pipe if it doesn't exist
+	if err := fm.createFIFO(); err != nil {
+		return fmt.Errorf("failed to create FIFO: %w", err)
+	}
+
+	fm.log.WithField("path", fm.path).WithField("format", fm.format).
+		Infof("metadata FIFO started")
+
+	// Start the writer goroutine
+	go fm.writerLoop()
+
+	return nil
+}
+
+// Stop stops the FIFO manager
+func (fm *FIFOManager) Stop() {
+	fm.mutex.Lock()
+	defer fm.mutex.Unlock()
+
+	if fm.closed {
+		return
+	}
+
+	fm.closed = true
+	close(fm.stopCh)
+
+	if fm.pipe != nil {
+		fm.pipe.Close()
+	}
+
+	// Remove the FIFO file
+	if fm.path != "" {
+		os.Remove(fm.path)
+	}
+
+	fm.log.WithField("writes", fm.writeCount).
+		WithField("errors", fm.errorCount).
+		WithField("drops", fm.dropCount).
+		Infof("metadata FIFO stopped")
+}
+
+// WriteMetadata writes metadata to the FIFO
+func (fm *FIFOManager) WriteMetadata(metadata *TrackMetadata) {
+	fm.mutex.RLock()
+	closed := fm.closed
+	fm.mutex.RUnlock()
+
+	if closed {
+		return
+	}
+
+	var data []byte
+	switch fm.format {
+	case "json":
+		data = metadata.ToJSONFormat()
+	case "xml": // ADD THIS CASE
+		data = metadata.ToXMLFormat()
+	default: // "dacp"
+		data = metadata.ToDACPFormat()
+	}
+
+	select {
+	case fm.buffer <- data:
+		// Successfully queued
+	case <-time.After(50 * time.Millisecond):
+		fm.dropCount++
+		// Drop the message if buffer is full
+	}
+}
+
+// createFIFO creates the named pipe
+func (fm *FIFOManager) createFIFO() error {
+	// Remove existing FIFO if it exists
+	os.Remove(fm.path)
+
+	// Create new FIFO
+	err := syscall.Mkfifo(fm.path, 0666)
+	if err != nil {
+		return fmt.Errorf("mkfifo failed: %w", err)
+	}
+
+	return nil
+}
+
+// openFIFO opens the FIFO for writing (non-blocking)
+func (fm *FIFOManager) openFIFO() error {
+	pipe, err := os.OpenFile(fm.path, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open FIFO: %w", err)
+	}
+
+	fm.pipe = pipe
+	return nil
+}
+
+// writerLoop handles writing to the FIFO
+func (fm *FIFOManager) writerLoop() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case data := <-fm.buffer:
+			if err := fm.writeToFIFO(data); err != nil {
+				fm.errorCount++
+				// Only log errors occasionally to avoid spam
+				if fm.errorCount%50 == 1 {
+					fm.log.WithError(err).Debugf("error writing to metadata FIFO")
+				}
+			} else {
+				fm.writeCount++
+			}
+
+		case <-ticker.C:
+			// Periodic check for reader presence
+			fm.checkFIFOConnection()
+
+		case <-fm.stopCh:
+			return
+		}
+	}
+}
+
+// writeToFIFO writes data to the FIFO, handling reconnection
+func (fm *FIFOManager) writeToFIFO(data []byte) error {
+	fm.mutex.Lock()
+	defer fm.mutex.Unlock()
+
+	if fm.pipe == nil {
+		if err := fm.openFIFO(); err != nil {
+			return err
+		}
+	}
+
+	_, err := fm.pipe.Write(data)
+	if err != nil {
+		// Close and attempt to reopen on error
+		fm.pipe.Close()
+		fm.pipe = nil
+		return err
+	}
+
+	return nil
+}
+
+// checkFIFOConnection checks if the FIFO is still connected
+func (fm *FIFOManager) checkFIFOConnection() {
+	fm.mutex.Lock()
+	defer fm.mutex.Unlock()
+
+	if fm.pipe == nil {
+		return
+	}
+
+	// Try a zero-byte write to check connection
+	_, err := fm.pipe.Write([]byte{})
+	if err != nil {
+		fm.pipe.Close()
+		fm.pipe = nil
+	}
+}

--- a/metadata/fifo.go
+++ b/metadata/fifo.go
@@ -96,12 +96,12 @@ func (fm *FIFOManager) WriteMetadata(metadata *TrackMetadata) {
 
 	var data []byte
 	switch fm.format {
-	case "json":
-		data = metadata.ToJSONFormat()
+	//	case "json":
+	//		data = metadata.ToJSONFormat()
 	case "xml": // ADD THIS CASE
 		data = metadata.ToXMLFormat()
-	default: // "dacp"
-		data = metadata.ToDACPFormat()
+		//default: // "dacp"
+		//	data = metadata.ToDACPFormat()
 	}
 
 	select {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,0 +1,203 @@
+package metadata
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// TrackMetadata represents the current track information
+type TrackMetadata struct {
+	Title       string    `json:"title"`
+	Artist      string    `json:"artist"`
+	Album       string    `json:"album"`
+	Duration    int64     `json:"duration_ms"`
+	Position    int64     `json:"position_ms"`
+	TrackID     string    `json:"track_id"`
+	Volume      int       `json:"volume"`
+	Playing     bool      `json:"playing"`
+	Timestamp   time.Time `json:"timestamp"`
+	ArtworkURL  string    `json:"artwork_url,omitempty"`
+	ArtworkData []byte    `json:"artwork_data,omitempty"`
+}
+
+// NewTrackMetadata creates a new TrackMetadata instance
+func NewTrackMetadata() *TrackMetadata {
+	return &TrackMetadata{
+		Timestamp: time.Now(),
+	}
+}
+
+// ToDACPFormat converts metadata to DACP pipe format compatible with forked-daapd
+func (tm *TrackMetadata) ToDACPFormat() []byte {
+	var result []byte
+
+	// DACP format uses key-value pairs with specific encoding
+	if tm.Title != "" {
+		result = append(result, encodeDACPItem("minm", tm.Title)...)
+	}
+	if tm.Artist != "" {
+		result = append(result, encodeDACPItem("asar", tm.Artist)...)
+	}
+	if tm.Album != "" {
+		result = append(result, encodeDACPItem("asal", tm.Album)...)
+	}
+
+	// Volume (0-100)
+	result = append(result, encodeDACPInt("cmvo", tm.Volume)...)
+
+	// Playing state: 2 = paused, 3 = playing, 4 = stopped
+	playState := 4 // stopped
+	if tm.Playing {
+		playState = 3 // playing
+	} else if tm.Duration > 0 {
+		playState = 2 // paused
+	}
+	result = append(result, encodeDACPInt("caps", playState)...)
+
+	// Duration in milliseconds
+	if tm.Duration > 0 {
+		result = append(result, encodeDACPInt("astm", int(tm.Duration))...)
+	}
+
+	// Position in milliseconds
+	result = append(result, encodeDACPInt("cant", int(tm.Position))...)
+
+	return result
+}
+
+// ToJSONFormat converts metadata to JSON format
+func (tm *TrackMetadata) ToJSONFormat() []byte {
+	data, _ := json.Marshal(tm)
+	return append(data, '\n')
+}
+
+// ToXMLFormat converts metadata to shairport-sync XML-style format// ToXMLFormat converts metadata to shairport-sync XML-style format
+func (tm *TrackMetadata) ToXMLFormat() []byte {
+	var result []byte
+
+	// Helper function to encode XML metadata item with hex-encoded type/code
+	encodeItem := func(itemType, code, data string) []byte {
+		// Convert 4-char codes to 8-digit hex (32-bit integers)
+		typeHex := fmt.Sprintf("%08x", stringToUint32(itemType))
+		codeHex := fmt.Sprintf("%08x", stringToUint32(code))
+
+		// Encode data as base64
+		encodedData := base64.StdEncoding.EncodeToString([]byte(data))
+
+		// Create XML-style item with hex-encoded type/code
+		item := fmt.Sprintf("<item><type>%s</type><code>%s</code><length>%d</length><data>%s</data></item>\n",
+			typeHex, codeHex, len(encodedData), encodedData)
+
+		return []byte(item)
+	}
+
+	// Track title
+	if tm.Title != "" {
+		result = append(result, encodeItem("core", "minm", tm.Title)...)
+	}
+
+	// Artist
+	if tm.Artist != "" {
+		result = append(result, encodeItem("core", "asar", tm.Artist)...)
+	}
+
+	// Album
+	if tm.Album != "" {
+		result = append(result, encodeItem("core", "asal", tm.Album)...)
+	}
+
+	// Playing state
+	playState := "stop"
+	if tm.Playing {
+		playState = "play"
+	} else if tm.Duration > 0 {
+		playState = "pause"
+	}
+	result = append(result, encodeItem("ssnc", "pply", playState)...)
+
+	// Volume (0-100)
+	volumeStr := fmt.Sprintf("%d", tm.Volume)
+	result = append(result, encodeItem("ssnc", "pvol", volumeStr)...)
+
+	// Position (in seconds)
+	positionSec := tm.Position / 1000
+	positionStr := fmt.Sprintf("%d", positionSec)
+	result = append(result, encodeItem("ssnc", "ppos", positionStr)...)
+
+	return result
+}
+
+// Make sure you also have this helper function:
+func stringToUint32(s string) uint32 {
+	if len(s) != 4 {
+		return 0
+	}
+	return uint32(s[0])<<24 | uint32(s[1])<<16 | uint32(s[2])<<8 | uint32(s[3])
+}
+
+// Update updates the metadata with new values
+func (tm *TrackMetadata) Update(title, artist, album, trackID string, duration, position int64, volume int, playing bool) {
+	tm.Title = title
+	tm.Artist = artist
+	tm.Album = album
+	tm.TrackID = trackID
+	tm.Duration = duration
+	tm.Position = position
+	tm.Volume = volume
+	tm.Playing = playing
+	//tm.ArtworkURL = artworkURL
+	//tm.ArtworkData = artworkData
+	tm.Timestamp = time.Now()
+}
+
+// UpdatePosition updates only the position and timestamp
+func (tm *TrackMetadata) UpdatePosition(position int64) {
+	tm.Position = position
+	tm.Timestamp = time.Now()
+}
+
+// UpdateVolume updates only the volume and timestamp
+func (tm *TrackMetadata) UpdateVolume(volume int) {
+	tm.Volume = volume
+	tm.Timestamp = time.Now()
+}
+
+// UpdatePlayingState updates only the playing state and timestamp
+func (tm *TrackMetadata) UpdatePlayingState(playing bool) {
+	tm.Playing = playing
+	tm.Timestamp = time.Now()
+}
+
+// encodeDACPItem encodes a string item in DACP format
+func encodeDACPItem(tag, value string) []byte {
+	valueBytes := []byte(value)
+	length := len(valueBytes)
+
+	result := make([]byte, 8+length)
+	copy(result[0:4], tag)
+	result[4] = byte(length >> 24)
+	result[5] = byte(length >> 16)
+	result[6] = byte(length >> 8)
+	result[7] = byte(length)
+	copy(result[8:], valueBytes)
+
+	return result
+}
+
+// encodeDACPInt encodes an integer item in DACP format
+func encodeDACPInt(tag string, value int) []byte {
+	result := make([]byte, 12)
+	copy(result[0:4], tag)
+	result[4] = 0
+	result[5] = 0
+	result[6] = 0
+	result[7] = 4
+	result[8] = byte(value >> 24)
+	result[9] = byte(value >> 16)
+	result[10] = byte(value >> 8)
+	result[11] = byte(value)
+
+	return result
+}

--- a/metadata/player_wrapper.go
+++ b/metadata/player_wrapper.go
@@ -1,0 +1,121 @@
+package metadata
+
+import (
+	"sync"
+	"time"
+
+	librespot "github.com/devgianlu/go-librespot"
+)
+
+// PlayerMetadata wraps metadata functionality for a player
+type PlayerMetadata struct {
+	fifoManager *FIFOManager
+	metadata    *TrackMetadata
+	mutex       sync.RWMutex
+	enabled     bool
+}
+
+// NewPlayerMetadata creates a new player metadata wrapper
+func NewPlayerMetadata(log librespot.Logger, config MetadataPipeConfig) *PlayerMetadata {
+	pm := &PlayerMetadata{
+		enabled: config.Enabled,
+	}
+
+	if config.Enabled {
+		pm.fifoManager = NewFIFOManager(log, config.Path, config.Format, config.BufferSize)
+		pm.metadata = NewTrackMetadata()
+	}
+
+	return pm
+}
+
+// Start starts the metadata system
+func (pm *PlayerMetadata) Start() error {
+	if !pm.enabled || pm.fifoManager == nil {
+		return nil
+	}
+
+	return pm.fifoManager.Start()
+}
+
+// Stop stops the metadata system
+func (pm *PlayerMetadata) Stop() {
+	if !pm.enabled || pm.fifoManager == nil {
+		return
+	}
+
+	pm.fifoManager.Stop()
+}
+
+// UpdateTrack updates track information
+func (pm *PlayerMetadata) UpdateTrack(title, artist, album, trackID string, duration time.Duration, playing bool) {
+	if !pm.enabled {
+		return
+	}
+
+	pm.mutex.Lock()
+	pm.metadata.Update(title, artist, album, trackID, duration.Milliseconds(), 0, pm.metadata.Volume, playing)
+	pm.mutex.Unlock()
+
+	pm.writeMetadata()
+}
+
+// UpdatePosition updates playback position
+func (pm *PlayerMetadata) UpdatePosition(position time.Duration) {
+	if !pm.enabled {
+		return
+	}
+
+	pm.mutex.Lock()
+	pm.metadata.UpdatePosition(position.Milliseconds())
+	pm.mutex.Unlock()
+
+	pm.writeMetadata()
+}
+
+// UpdateVolume updates volume
+func (pm *PlayerMetadata) UpdateVolume(volume int) {
+	if !pm.enabled {
+		return
+	}
+
+	pm.mutex.Lock()
+	pm.metadata.UpdateVolume(volume)
+	pm.mutex.Unlock()
+
+	pm.writeMetadata()
+}
+
+// UpdatePlayingState updates playing state
+func (pm *PlayerMetadata) UpdatePlayingState(playing bool) {
+	if !pm.enabled {
+		return
+	}
+
+	pm.mutex.Lock()
+	pm.metadata.UpdatePlayingState(playing)
+	pm.mutex.Unlock()
+
+	pm.writeMetadata()
+}
+
+// writeMetadata writes current metadata to FIFO
+func (pm *PlayerMetadata) writeMetadata() {
+	if pm.fifoManager == nil {
+		return
+	}
+
+	pm.mutex.RLock()
+	metadataCopy := *pm.metadata // Make a copy to avoid race conditions
+	pm.mutex.RUnlock()
+
+	pm.fifoManager.WriteMetadata(&metadataCopy)
+}
+
+// MetadataPipeConfig represents metadata pipe configuration
+type MetadataPipeConfig struct {
+	Enabled    bool
+	Path       string
+	Format     string
+	BufferSize int
+}

--- a/metadata/player_wrapper.go
+++ b/metadata/player_wrapper.go
@@ -47,14 +47,14 @@ func (pm *PlayerMetadata) Stop() {
 	pm.fifoManager.Stop()
 }
 
-// UpdateTrack updates track information
-func (pm *PlayerMetadata) UpdateTrack(title, artist, album, trackID string, duration time.Duration, playing bool) {
+// Update UpdateTrack method signature:
+func (pm *PlayerMetadata) UpdateTrack(title, artist, album, trackID string, duration time.Duration, playing bool, artworkURL string, artworkData []byte) {
 	if !pm.enabled {
 		return
 	}
 
 	pm.mutex.Lock()
-	pm.metadata.Update(title, artist, album, trackID, duration.Milliseconds(), 0, pm.metadata.Volume, playing)
+	pm.metadata.Update(title, artist, album, trackID, duration.Milliseconds(), 0, pm.metadata.Volume, playing, artworkURL, artworkData)
 	pm.mutex.Unlock()
 
 	pm.writeMetadata()

--- a/player/player.go
+++ b/player/player.go
@@ -79,6 +79,13 @@ type playerCmdDataSet struct {
 	drop    bool
 }
 
+type MetadataCallback interface {
+	UpdateTrack(title, artist, album, trackID string, duration time.Duration, playing bool)
+	UpdatePosition(position time.Duration)
+	UpdateVolume(volume int)
+	UpdatePlayingState(playing bool)
+}
+
 type Options struct {
 	Spclient *spclient.Spclient
 	AudioKey *audio.KeyProvider
@@ -143,6 +150,7 @@ type Options struct {
 	//
 	// This is only supported on the pipe backend.
 	AudioOutputPipeFormat string
+	MetadataCallback      MetadataCallback
 }
 
 func NewPlayer(opts *Options) (*Player, error) {

--- a/player/player.go
+++ b/player/player.go
@@ -79,8 +79,9 @@ type playerCmdDataSet struct {
 	drop    bool
 }
 
+// Update MetadataCallback interface:
 type MetadataCallback interface {
-	UpdateTrack(title, artist, album, trackID string, duration time.Duration, playing bool)
+	UpdateTrack(title, artist, album, trackID string, duration time.Duration, playing bool, artworkURL string, artworkData []byte)
 	UpdatePosition(position time.Duration)
 	UpdateVolume(volume int)
 	UpdatePlayingState(playing bool)


### PR DESCRIPTION
Add metadata to fifo pipe output as requested in: Add metadata output to a pipe as it is in librespot-java  #157

Functionally this works very well showing track info, duration and timing, and artwork when piped into owntone and the Home Assistant dashboard when running when running in an addon.  

I used AI to help write it and don't see any issues at this point.  This is my first pull request so I expect there will be nits and other issues, but I will do will what I can to help push this forward.  

