### PR TITLE
fix #201: separate config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN apk update && apk -U --no-cache add libpulse avahi libgcc gcompat alsa-lib
 
 COPY --from=build /src/daemon /usr/bin/go-librespot
 
-CMD ["/usr/bin/go-librespot", "--config_dir", "/config"]
+CMD ["/usr/bin/go-librespot", "--state", "/state", "--config", "/config/config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN apk update && apk -U --no-cache add libpulse avahi libgcc gcompat alsa-lib
 
 COPY --from=build /src/go-librespot /usr/bin/go-librespot
 
-CMD ["/usr/bin/go-librespot", "--config_dir", "/config"]
+CMD ["/usr/bin/go-librespot", "--state", "/state", "--config", "/config/config.yaml"]

--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ Details about cross-compiling go-librespot are described [here](/CROSS_COMPILE.m
 
 The default directory for configuration files is `~/.config/go-librespot`. On macOS devices, this is
 `~/Library/Application Support/go-librespot`. You can change this directory with the
-`-config_dir` flag. The configuration directory contains:
+`--config_dir` flag. The configuration directory contains:
 
 - `config.yml`: The main configuration (does not exist by default)
 - `state.json`: The player state and credentials
 - `lockfile`: A lockfile to prevent running multiple instances on the same configuration
+
+You may also specify a custom config file with the `--config` flag.
 
 The full configuration schema is available [here](/config_schema.json), only the main options are detailed below.
 

--- a/README.md
+++ b/README.md
@@ -60,15 +60,18 @@ Details about cross-compiling go-librespot are described [here](/CROSS_COMPILE.m
 
 ## Configuration
 
-The default directory for configuration files is `~/.config/go-librespot`. On macOS devices, this is
-`~/Library/Application Support/go-librespot`. You can change this directory with the
-`--config_dir` flag. The configuration directory contains:
+The main configuration files is `~/.config/go-librespot/config.yaml`. On macOS devices, this is
+`~/Library/Application Support/go-librespot/config.yaml`. It does not exist by default.
 
-- `config.yml`: The main configuration (does not exist by default)
+You can change this path with the `--config` flag.
+
+State files are stored in `~/.local/state/go-librespot` (`~/Library/Application Support/go-librespot` on macOS).
+
+You can change this directory with the `--state` flag.
+
+The state directory contains:
 - `state.json`: The player state and credentials
-- `lockfile`: A lockfile to prevent running multiple instances on the same configuration
-
-You may also specify a custom config file with the `--config` flag.
+- `lockfile`: A lockfile to prevent multiple instances using the same state
 
 The full configuration schema is available [here](/config_schema.json), only the main options are detailed below.
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,19 @@ Details about cross-compiling go-librespot are described [here](/CROSS_COMPILE.m
 
 ## Configuration
 
-The default directory for configuration files is `~/.config/go-librespot`. On macOS this is
-`~/Library/Application Support/go-librespot`. On Windows it is `%APPDATA%\go-librespot`. You can change this directory with the
-`-config_dir` flag. The configuration directory contains:
+The main configuration file is `~/.config/go-librespot/config.yaml`. On macOS this is
+`~/Library/Application Support/go-librespot/config.yaml`. On Windows it is `%APPDATA%\go-librespot\config.yaml`. It does not
+exist by default.
 
-- `config.yml`: The main configuration (does not exist by default)
+You can change this path with the `--config` flag.
+
+State files are stored in `~/.local/state/go-librespot` (`~/Library/Application Support/go-librespot` on macOS, `%LOCALAPPDATA%\go-librespot` on Windows).
+
+You can change this directory with the `--state` flag.
+
+The state directory contains:
 - `state.json`: The player state and credentials
-- `lockfile`: A lockfile to prevent running multiple instances on the same configuration
+- `lockfile`: A lockfile to prevent multiple instances using the same state
 
 The full configuration schema is available [here](/config_schema.json), only the main options are detailed below.
 

--- a/cmd/daemon/cli_config.go
+++ b/cmd/daemon/cli_config.go
@@ -23,10 +23,11 @@ import (
 var errAlreadyRunning = errors.New("go-librespot is already running")
 
 type cliConfig struct {
-	ConfigDir string `koanf:"config_dir"`
+	StateDir   string `koanf:"state"`
+	ConfigPath string `koanf:"config"`
 
 	// Keep this around so the lockfile finalizer doesn't release it.
-	configLock *flock.Flock
+	stateLock *flock.Flock
 
 	LogLevel            log.Level `koanf:"log_level"`
 	LogDisableTimestamp bool      `koanf:"log_disable_timestamp"`
@@ -144,7 +145,7 @@ func (c *cliConfig) toDaemonConfig() *daemon.Config {
 		if cacheDir, err := os.UserCacheDir(); err == nil {
 			dc.Cache.Dir = filepath.Join(cacheDir, "go-librespot")
 		} else {
-			dc.Cache.Dir = filepath.Join(c.ConfigDir, "cache")
+			dc.Cache.Dir = filepath.Join(c.StateDir, "cache")
 		}
 	}
 	// The value is validated in loadCLIConfig, so the error is unreachable here.
@@ -157,8 +158,18 @@ func (c *cliConfig) toDaemonConfig() *daemon.Config {
 	return dc
 }
 
+// backwards compatibility for config_dir flag
+func aliasNormalizeFunc(f *flag.FlagSet, name string) flag.NormalizedName {
+	switch name {
+	case "config_dir":
+		name = "state"
+	}
+	return flag.NormalizedName(name)
+}
+
 func loadCLIConfig(cfg *cliConfig) error {
 	f := flag.NewFlagSet("config", flag.ContinueOnError)
+	f.SetNormalizeFunc(aliasNormalizeFunc)
 	f.Usage = func() {
 		fmt.Println(f.FlagUsages())
 		os.Exit(0)
@@ -167,8 +178,15 @@ func loadCLIConfig(cfg *cliConfig) error {
 	if err != nil {
 		return err
 	}
-	defaultConfigDir := filepath.Join(userConfigDir, "go-librespot")
-	f.StringVar(&cfg.ConfigDir, "config_dir", defaultConfigDir, "the configuration directory")
+	defaultConfigPath := filepath.Join(userConfigDir, "go-librespot", "config.yaml")
+	f.StringVar(&cfg.ConfigPath, "config", defaultConfigPath, "the configuration file")
+
+	userStateDir, err := UserStateDir()
+	if err != nil {
+		return err
+	}
+	defaultStatePath := filepath.Join(userStateDir, "go-librespot")
+	f.StringVar(&cfg.StateDir, "state", defaultStatePath, "the state directory")
 
 	var configOverrides []string
 	f.StringArrayVarP(&configOverrides, "conf", "c", nil, "override config values (format: field=value, use field1.field2=value for nested fields)")
@@ -177,14 +195,14 @@ func loadCLIConfig(cfg *cliConfig) error {
 		return err
 	}
 
-	if err := os.MkdirAll(cfg.ConfigDir, 0o700); err != nil {
-		return fmt.Errorf("failed creating config directory: %w", err)
+	if err := os.MkdirAll(cfg.StateDir, 0o700); err != nil {
+		return fmt.Errorf("failed creating state directory: %w", err)
 	}
 
-	lockFilePath := filepath.Join(cfg.ConfigDir, "lockfile")
-	cfg.configLock = flock.New(lockFilePath)
-	if locked, err := cfg.configLock.TryLock(); err != nil {
-		return fmt.Errorf("could not lock config directory: %w", err)
+	lockFilePath := filepath.Join(cfg.StateDir, "lockfile")
+	cfg.stateLock = flock.New(lockFilePath)
+	if locked, err := cfg.stateLock.TryLock(); err != nil {
+		return fmt.Errorf("could not lock state directory: %w", err)
 	} else if !locked {
 		return fmt.Errorf("%w (lockfile: %s)", errAlreadyRunning, lockFilePath)
 	}
@@ -217,10 +235,11 @@ func loadCLIConfig(cfg *cliConfig) error {
 	}, "."), nil)
 
 	var configPath string
-	if _, err := os.Stat(filepath.Join(cfg.ConfigDir, "config.yaml")); os.IsNotExist(err) {
-		configPath = filepath.Join(cfg.ConfigDir, "config.yml")
+	if _, err := os.Stat(cfg.ConfigPath); os.IsNotExist(err) {
+		// postel: allow .yml in place of .yaml
+		configPath = strings.TrimSuffix(cfg.ConfigPath, filepath.Ext(cfg.ConfigPath)) + ".yml"
 	} else {
-		configPath = filepath.Join(cfg.ConfigDir, "config.yaml")
+		configPath = cfg.ConfigPath
 	}
 
 	if err := k.Load(file.Provider(configPath), yaml.Parser()); err != nil {

--- a/cmd/daemon/cli_config_test.go
+++ b/cmd/daemon/cli_config_test.go
@@ -57,19 +57,21 @@ func TestParseSize(t *testing.T) {
 
 func TestLoadCLIConfigWaitForReaderFlag(t *testing.T) {
 	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	stateDir := filepath.Join(dir, "state")
 
 	config := []byte("audio_backend: pipe\naudio_output_pipe: /tmp/fifo/go-spotify\naudio_output_pipe_wait_for_reader: true\n")
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), config, 0o600))
+	require.NoError(t, os.WriteFile(configPath, config, 0o600))
 
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
-	os.Args = []string{"test", "--config_dir", dir}
+	os.Args = []string{"test", "--config", configPath, "--state", stateDir}
 
 	cfg := &cliConfig{}
 	require.NoError(t, loadCLIConfig(cfg))
 	t.Cleanup(func() {
-		if cfg.configLock != nil {
-			_ = cfg.configLock.Unlock()
+		if cfg.stateLock != nil {
+			_ = cfg.stateLock.Unlock()
 		}
 	})
 	require.True(t, cfg.AudioOutputPipeWaitForReader, "audio_output_pipe_wait_for_reader was not parsed from the config file")

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -381,6 +381,7 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 
 type Config struct {
 	ConfigDir string `koanf:"config_dir"`
+	ConfigPath string `koanf:"config"`
 
 	// We need to keep this object around, otherwise it gets GC'd and the
 	// finalizer will run, probably closing the lock.
@@ -453,6 +454,9 @@ func loadConfig(cfg *Config) error {
 	defaultConfigDir := filepath.Join(userConfigDir, "go-librespot")
 	f.StringVar(&cfg.ConfigDir, "config_dir", defaultConfigDir, "the configuration directory")
 
+	defaultConfigPath := filepath.Join(defaultConfigDir, "config.yaml")
+	f.StringVar(&cfg.ConfigPath, "config", defaultConfigPath, "the configuration file")
+
 	var configOverrides []string
 	f.StringArrayVarP(&configOverrides, "conf", "c", nil, "override config values (format: field=value, use field1.field2=value for nested fields)")
 
@@ -505,10 +509,10 @@ func loadConfig(cfg *Config) error {
 
 	// load file configuration (if available)
 	var configPath string
-	if _, err := os.Stat(filepath.Join(cfg.ConfigDir, "config.yaml")); os.IsNotExist(err) {
+	if _, err := os.Stat(cfg.ConfigPath); os.IsNotExist(err) {
 		configPath = filepath.Join(cfg.ConfigDir, "config.yml")
 	} else {
-		configPath = filepath.Join(cfg.ConfigDir, "config.yaml")
+		configPath = cfg.ConfigPath
 	}
 
 	if err := k.Load(file.Provider(configPath), yaml.Parser()); err != nil {

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -465,7 +465,7 @@ func loadConfig(cfg *Config) error {
 	defaultConfigPath := filepath.Join(userConfigDir, "go-librespot", "config.yaml")
 	f.StringVar(&cfg.ConfigPath, "config", defaultConfigPath, "the configuration file")
 
-	userStateDir, err := os.UserConfigDir()
+	userStateDir, err := UserStateDir() // local implementation
 	if err != nil {
 		return err
 	}

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -80,7 +80,7 @@ func NewApp(cfg *Config) (app *App, err error) {
 	}
 
 	app.state.SetLogger(app.log)
-	if err := app.state.Read(cfg.ConfigDir); err != nil {
+	if err := app.state.Read(cfg.StateDir); err != nil {
 		return nil, err
 	}
 
@@ -380,12 +380,12 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 }
 
 type Config struct {
-	ConfigDir string `koanf:"config_dir"`
+	StateDir   string `koanf:"state"`
 	ConfigPath string `koanf:"config"`
 
 	// We need to keep this object around, otherwise it gets GC'd and the
 	// finalizer will run, probably closing the lock.
-	configLock *flock.Flock
+	stateLock *flock.Flock
 
 	LogLevel                      log.Level `koanf:"log_level"`
 	LogDisableTimestamp           bool      `koanf:"log_disable_timestamp"`
@@ -441,8 +441,19 @@ type Config struct {
 	} `koanf:"credentials"`
 }
 
+// backwards compatibility for config_dir flag
+func aliasNormalizeFunc(f *flag.FlagSet, name string) flag.NormalizedName {
+	switch name {
+	case "config_dir":
+		name = "state"
+		break
+	}
+	return flag.NormalizedName(name)
+}
+
 func loadConfig(cfg *Config) error {
 	f := flag.NewFlagSet("config", flag.ContinueOnError)
+	f.SetNormalizeFunc(aliasNormalizeFunc)
 	f.Usage = func() {
 		fmt.Println(f.FlagUsages())
 		os.Exit(0)
@@ -451,11 +462,15 @@ func loadConfig(cfg *Config) error {
 	if err != nil {
 		return err
 	}
-	defaultConfigDir := filepath.Join(userConfigDir, "go-librespot")
-	f.StringVar(&cfg.ConfigDir, "config_dir", defaultConfigDir, "the configuration directory")
-
-	defaultConfigPath := filepath.Join(defaultConfigDir, "config.yaml")
+	defaultConfigPath := filepath.Join(userConfigDir, "go-librespot", "config.yaml")
 	f.StringVar(&cfg.ConfigPath, "config", defaultConfigPath, "the configuration file")
+
+	userStateDir, err := os.UserConfigDir()
+	if err != nil {
+		return err
+	}
+	defaultStatePath := filepath.Join(userStateDir, "go-librespot")
+	f.StringVar(&cfg.StateDir, "state", defaultStatePath, "the state directory")
 
 	var configOverrides []string
 	f.StringArrayVarP(&configOverrides, "conf", "c", nil, "override config values (format: field=value, use field1.field2=value for nested fields)")
@@ -465,18 +480,18 @@ func loadConfig(cfg *Config) error {
 		return err
 	}
 
-	// Make config directory if needed.
-	err = os.MkdirAll(cfg.ConfigDir, 0o700)
+	// Make state directory if needed.
+	err = os.MkdirAll(cfg.StateDir, 0o700)
 	if err != nil {
-		return fmt.Errorf("failed creating config directory: %w", err)
+		return fmt.Errorf("failed creating state directory: %w", err)
 	}
 
-	// Lock the config directory (to ensure multiple instances won't clobber
+	// Lock the state directory (to ensure multiple instances won't clobber
 	// each others state).
-	lockFilePath := filepath.Join(cfg.ConfigDir, "lockfile")
-	cfg.configLock = flock.New(lockFilePath)
-	if locked, err := cfg.configLock.TryLock(); err != nil {
-		return fmt.Errorf("could not lock config directory: %w", err)
+	lockFilePath := filepath.Join(cfg.StateDir, "lockfile")
+	cfg.stateLock = flock.New(lockFilePath)
+	if locked, err := cfg.stateLock.TryLock(); err != nil {
+		return fmt.Errorf("could not lock state directory: %w", err)
 	} else if !locked {
 		// Lock already taken! Looks like go-librespot is already running.
 		return fmt.Errorf("%w (lockfile: %s)", errAlreadyRunning, lockFilePath)
@@ -510,7 +525,8 @@ func loadConfig(cfg *Config) error {
 	// load file configuration (if available)
 	var configPath string
 	if _, err := os.Stat(cfg.ConfigPath); os.IsNotExist(err) {
-		configPath = filepath.Join(cfg.ConfigDir, "config.yml")
+		// postel: allow .yml in place of .yaml
+		configPath = strings.TrimSuffix(cfg.ConfigPath, filepath.Ext(cfg.ConfigPath)) + ".yml"
 	} else {
 		configPath = cfg.ConfigPath
 	}

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -40,8 +40,8 @@ func main() {
 	logger.Infof("running go-librespot %s", librespot.VersionNumberString())
 
 	store := NewFileStateStore(
-		filepath.Join(cfg.ConfigDir, "state.json"),
-		filepath.Join(cfg.ConfigDir, "credentials.json"),
+		filepath.Join(cfg.StateDir, "state.json"),
+		filepath.Join(cfg.StateDir, "credentials.json"),
 		logEntry,
 	)
 

--- a/cmd/daemon/os.go
+++ b/cmd/daemon/os.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"runtime"
+)
+
+// UserStateDir is not included in the `os` package.
+// It returns the default root directory to use for user-specific
+// state data. Users should create their own application-specific subdirectory
+// within this one and use that.
+//
+// On Unix systems, it returns $XDG_STATE_HOME as specified by
+// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html if
+// non-empty, else $HOME/.local/state.
+// On other systems it returns os.UserConfigDir
+//
+// If the location cannot be determined (for example, $HOME is not defined)
+// then it will return an error.
+func UserStateDir() (string, error) {
+	var dir string
+
+	switch runtime.GOOS {
+	case "windows", "darwin", "ios", "plan9":
+		return os.UserConfigDir()
+	default: // Unix, as UserConfigDir
+		dir = os.Getenv("XDG_STATE_HOME")
+		if dir == "" {
+			dir = os.Getenv("HOME")
+			if dir == "" {
+				return "", errors.New("neither $XDG_STATE_HOME nor $HOME are defined")
+			}
+			dir += "/.local/state"
+		}
+	}
+
+	return dir, nil
+}

--- a/docker-compose.pulse.yml
+++ b/docker-compose.pulse.yml
@@ -5,6 +5,7 @@ services:
     network_mode: host
     userns_mode: keep-id
     volumes:
+      - ~/.local/state/go-librespot:/state
       - ~/.config/go-librespot:/config
       - ~/.config/pulse/cookie:/pulse_cookie:ro
       - /run/user/1000/pulse/native:/pulse_native # Replace 1000 with your UID


### PR DESCRIPTION
Fixes #201

This moves state files from `os.UserConfigDir` to a user state dir by default.

The config file remains in the original location.

- **add --config flag**
  - can specify a custom config file independent of state files
  - default config remains at `os.UserConfigDir()`

- **add --state flag**
  - move default state to a state dir
      - under Unix this is `~/.local/state`
      - for other OSes this is `os.UserConfigDir()`
  - make `config_dir` an alias for `state`

To use the old behaviour:

```bash
go run ./cmd/daemon --state $XDG_CONFIG_HOME/go-librespot
```

