### PR TITLE
Draft: fix: make HttpChunkedReader.ReadAt return io.EOF in case the chunks are finished

### DIFF
--- a/audio/chunked_reader.go
+++ b/audio/chunked_reader.go
@@ -221,7 +221,7 @@ func (r *HttpChunkedReader) ReadAt(p []byte, pos int64) (n int, _ error) {
 	n = 0
 	for len(p) > 0 {
 		if chunkIdx >= len(r.chunks) {
-			return n, nil
+			return n, io.EOF
 		}
 
 		// get the chunk data


### PR DESCRIPTION
See: #211 