### PR TITLE
fix FreeBSD support

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -127,7 +127,7 @@ func GetPlatformSpecificData() *clienttokenpb.PlatformSpecificData {
 				Ios: &clienttokenpb.NativeIOSData{},
 			},
 		}
-	case "linux":
+	case "linux", "freebsd":
 		return &clienttokenpb.PlatformSpecificData{
 			Data: &clienttokenpb.PlatformSpecificData_DesktopLinux{
 				DesktopLinux: &clienttokenpb.NativeDesktopLinuxData{},


### PR DESCRIPTION
 failed obtaining client token: invalid status code from clienttoken: 400

it enable go-librespot to run on FreeBSD