### PR TITLE
chore: do not link alsa statically

### DIFF
--- a/vcpkg-triplets/base-linux.cmake
+++ b/vcpkg-triplets/base-linux.cmake
@@ -7,3 +7,8 @@ set(VCPKG_BUILD_TYPE release)
 if(PORT STREQUAL "libflac")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS -DBUILD_CXXLIBS=OFF)
 endif()
+
+if(PORT STREQUAL "alsa")
+    set(VCPKG_CRT_LINKAGE dynamic)
+    set(VCPKG_LIBRARY_LINKAGE dynamic)
+endif()


### PR DESCRIPTION
This causes compatibility issues. See #251