### PR TITLE
fix: unset Zeroconf user on restore error to allow takeover

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -314,6 +314,9 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 				newAppPlayer, err := appPlayerFunc(ctx)
 				if err != nil {
 					log.WithError(err).Errorf("failed restoring session after logout")
+
+					// unset the zeroconf user
+					z.SetCurrentUser("")
 				} else if newAppPlayer == nil {
 					// unset the zeroconf user
 					z.SetCurrentUser("")


### PR DESCRIPTION
Fixes #240, supersedes #258

If we fail to restore the previous session when a user disconnects, unset the current Zeroconf user so that it can login again.

Without this, we would just return without actually attempting:
https://github.com/devgianlu/go-librespot/blob/84f10376c135a10580f551d31917197e283cf2f7/zeroconf/zeroconf.go#L185-L194