### PR TITLE
fix: manually unset player options based on disallow restrictions

### DIFF
--- a/cmd/daemon/controls.go
+++ b/cmd/daemon/controls.go
@@ -240,6 +240,16 @@ func (p *AppPlayer) loadContext(ctx context.Context, spotCtx *connectpb.Context,
 	p.state.player.Restrictions = spotCtx.Restrictions
 	p.state.player.ContextRestrictions = spotCtx.Restrictions
 
+	if len(spotCtx.Restrictions.DisallowTogglingShuffleReasons) > 0 {
+		p.state.player.Options.ShufflingContext = false
+	}
+	if len(spotCtx.Restrictions.DisallowTogglingRepeatTrackReasons) > 0 {
+		p.state.player.Options.RepeatingTrack = false
+	}
+	if len(spotCtx.Restrictions.DisallowTogglingRepeatContextReasons) > 0 {
+		p.state.player.Options.RepeatingContext = false
+	}
+
 	if p.state.player.ContextMetadata == nil {
 		p.state.player.ContextMetadata = map[string]string{}
 	}


### PR DESCRIPTION
This fixes a bug where go-librespot would start infinitely resolving a station to shuffle it.