### PR TITLE
Add a playback_ready field to the "/" api response

### DIFF
--- a/api-spec.yml
+++ b/api-spec.yml
@@ -47,7 +47,7 @@ components:
 paths:
   /:
     get:
-      description: Returns an empty object, used to very API is reachable
+      description: Returns API reachability and playback readiness
       responses:
         200:
           description: API is ok
@@ -55,6 +55,10 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  playback_ready:
+                    description: Whether the daemon is fully bootstrapped and ready to accept /player/play
+                    type: boolean
   /status:
     get:
       description: Returns the player status

--- a/cmd/daemon/api_server.go
+++ b/cmd/daemon/api_server.go
@@ -34,8 +34,6 @@ type ConcreteApiServer struct {
 	certFile    string
 	keyFile     string
 
-	playbackReady func() bool
-
 	close    bool
 	listener net.Listener
 
@@ -57,6 +55,7 @@ var (
 type ApiRequestType string
 
 const (
+	ApiRequestTypeRoot                ApiRequestType = "root"
 	ApiRequestTypeWebApi              ApiRequestType = "web_api"
 	ApiRequestTypeStatus              ApiRequestType = "status"
 	ApiRequestTypeResume              ApiRequestType = "resume"
@@ -325,8 +324,8 @@ type ApiEventDataShuffleContext struct {
 	Value bool `json:"value"`
 }
 
-func NewApiServer(log librespot.Logger, address string, port int, allowOrigin string, certFile string, keyFile string, playbackReady func() bool) (_ ApiServer, err error) {
-	s := &ConcreteApiServer{log: log, allowOrigin: allowOrigin, certFile: certFile, keyFile: keyFile, playbackReady: playbackReady}
+func NewApiServer(log librespot.Logger, address string, port int, allowOrigin string, certFile string, keyFile string) (_ ApiServer, err error) {
+	s := &ConcreteApiServer{log: log, allowOrigin: allowOrigin, certFile: certFile, keyFile: keyFile}
 	s.requests = make(chan ApiRequest)
 
 	s.listener, err = net.Listen("tcp", fmt.Sprintf("%s:%d", address, port))
@@ -414,14 +413,12 @@ func jsonDecode(r *http.Request, v any) error {
 func (s *ConcreteApiServer) serve() {
 	m := http.NewServeMux()
 	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		resp := ApiResponseRoot{}
-		if s.playbackReady != nil {
-			resp.PlaybackReady = s.playbackReady()
+		if r.Method != "GET" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
 		}
 
-		_ = json.NewEncoder(w).Encode(resp)
+		s.handleRequest(ApiRequest{Type: ApiRequestTypeRoot}, w)
 	})
 	m.Handle("/web-api/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.handleRequest(ApiRequest{

--- a/cmd/daemon/api_server.go
+++ b/cmd/daemon/api_server.go
@@ -91,6 +91,7 @@ const (
 	ApiEventTypeRepeatTrack    ApiEventType = "repeat_track"
 	ApiEventTypeRepeatContext  ApiEventType = "repeat_context"
 	ApiEventTypeShuffleContext ApiEventType = "shuffle_context"
+	ApiEventTypePlaybackReady  ApiEventType = "playback_ready"
 )
 
 type ApiRequest struct {

--- a/cmd/daemon/api_server.go
+++ b/cmd/daemon/api_server.go
@@ -34,6 +34,8 @@ type ConcreteApiServer struct {
 	certFile    string
 	keyFile     string
 
+	playbackReady func() bool
+
 	close    bool
 	listener net.Listener
 
@@ -251,6 +253,10 @@ type ApiResponseStatus struct {
 	Track          *ApiResponseStatusTrack `json:"track"`
 }
 
+type ApiResponseRoot struct {
+	PlaybackReady bool `json:"playback_ready"`
+}
+
 type ApiResponseVolume struct {
 	Value uint32 `json:"value"`
 	Max   uint32 `json:"max"`
@@ -318,8 +324,8 @@ type ApiEventDataShuffleContext struct {
 	Value bool `json:"value"`
 }
 
-func NewApiServer(log librespot.Logger, address string, port int, allowOrigin string, certFile string, keyFile string) (_ ApiServer, err error) {
-	s := &ConcreteApiServer{log: log, allowOrigin: allowOrigin, certFile: certFile, keyFile: keyFile}
+func NewApiServer(log librespot.Logger, address string, port int, allowOrigin string, certFile string, keyFile string, playbackReady func() bool) (_ ApiServer, err error) {
+	s := &ConcreteApiServer{log: log, allowOrigin: allowOrigin, certFile: certFile, keyFile: keyFile, playbackReady: playbackReady}
 	s.requests = make(chan ApiRequest)
 
 	s.listener, err = net.Listen("tcp", fmt.Sprintf("%s:%d", address, port))
@@ -408,7 +414,13 @@ func (s *ConcreteApiServer) serve() {
 	m := http.NewServeMux()
 	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte("{}"))
+
+		resp := ApiResponseRoot{}
+		if s.playbackReady != nil {
+			resp.PlaybackReady = s.playbackReady()
+		}
+
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	m.Handle("/web-api/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.handleRequest(ApiRequest{

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	librespot "github.com/devgianlu/go-librespot"
@@ -49,9 +50,10 @@ type App struct {
 	clientToken string
 	state       librespot.AppState
 
-	server   ApiServer
-	mpris    mpris.Server
-	logoutCh chan *AppPlayer
+	server        ApiServer
+	mpris         mpris.Server
+	logoutCh      chan *AppPlayer
+	currentPlayer atomic.Pointer[AppPlayer]
 }
 
 func parseDeviceType(val string) (devicespb.DeviceType, error) {
@@ -118,6 +120,11 @@ func NewApp(cfg *Config) (app *App, err error) {
 	}
 
 	return app, nil
+}
+
+func (app *App) playbackReady() bool {
+	appPlayer := app.currentPlayer.Load()
+	return appPlayer != nil && appPlayer.playbackReady()
 }
 
 func (app *App) newAppPlayer(ctx context.Context, creds any) (_ *AppPlayer, err error) {
@@ -243,6 +250,8 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 			panic("zeroconf is disabled and no credentials are present")
 		}
 
+		app.currentPlayer.Store(appPlayer)
+		defer app.currentPlayer.Store(nil)
 		appPlayer.Run(ctx, app.server.Receive(), app.mpris.Receive())
 		return nil
 	}
@@ -271,6 +280,7 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 			Debugf("initializing zeroconf session")
 
 		apiCh = make(chan ApiRequest)
+		app.currentPlayer.Store(currentPlayer)
 		go currentPlayer.Run(ctx, apiCh, app.mpris.Receive())
 
 		// let zeroconf know that we already have a user
@@ -303,6 +313,7 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 					continue
 				}
 
+				app.currentPlayer.Store(nil)
 				currentPlayer.Close()
 				currentPlayer = nil
 
@@ -325,6 +336,7 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 					apiCh = make(chan ApiRequest)
 					currentPlayer = newAppPlayer
 
+					app.currentPlayer.Store(newAppPlayer)
 					go newAppPlayer.Run(ctx, apiCh, app.mpris.Receive())
 
 					// let zeroconf know that we already have a user
@@ -339,6 +351,7 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 
 	return z.Serve(func(req zeroconf.NewUserRequest) bool {
 		if currentPlayer != nil {
+			app.currentPlayer.Store(nil)
 			currentPlayer.Close()
 			currentPlayer = nil
 
@@ -374,6 +387,7 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 				Debugf("persisted zeroconf credentials")
 		}
 
+		app.currentPlayer.Store(newAppPlayer)
 		go newAppPlayer.Run(ctx, apiCh, app.mpris.Receive())
 		return true
 	})
@@ -585,7 +599,7 @@ func main() {
 
 	// create api server if needed
 	if cfg.Server.Enabled {
-		app.server, err = NewApiServer(app.log, cfg.Server.Address, cfg.Server.Port, cfg.Server.AllowOrigin, cfg.Server.CertFile, cfg.Server.KeyFile)
+		app.server, err = NewApiServer(app.log, cfg.Server.Address, cfg.Server.Port, cfg.Server.AllowOrigin, cfg.Server.CertFile, cfg.Server.KeyFile, app.playbackReady)
 		if err != nil {
 			log.WithError(err).Fatal("failed creating api server")
 		}

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	librespot "github.com/devgianlu/go-librespot"
@@ -50,10 +49,9 @@ type App struct {
 	clientToken string
 	state       librespot.AppState
 
-	server        ApiServer
-	mpris         mpris.Server
-	logoutCh      chan *AppPlayer
-	currentPlayer atomic.Pointer[AppPlayer]
+	server   ApiServer
+	mpris    mpris.Server
+	logoutCh chan *AppPlayer
 }
 
 func parseDeviceType(val string) (devicespb.DeviceType, error) {
@@ -122,18 +120,14 @@ func NewApp(cfg *Config) (app *App, err error) {
 	return app, nil
 }
 
-func (app *App) playbackReady() bool {
-	appPlayer := app.currentPlayer.Load()
-	return appPlayer != nil && appPlayer.playbackReady()
-}
-
 func (app *App) newAppPlayer(ctx context.Context, creds any) (_ *AppPlayer, err error) {
 	appPlayer := &AppPlayer{
-		app:          app,
-		stop:         make(chan struct{}, 1),
-		logout:       app.logoutCh,
-		countryCode:  new(string),
-		volumeUpdate: make(chan float32, 1),
+		app:             app,
+		stop:            make(chan struct{}, 1),
+		logout:          app.logoutCh,
+		countryCode:     new(string),
+		volumeUpdate:    make(chan float32, 1),
+		playbackReadyCh: make(chan struct{}),
 	}
 
 	appPlayer.prefetchTimer = time.NewTimer(math.MaxInt64)
@@ -250,8 +244,6 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 			panic("zeroconf is disabled and no credentials are present")
 		}
 
-		app.currentPlayer.Store(appPlayer)
-		defer app.currentPlayer.Store(nil)
 		appPlayer.Run(ctx, app.server.Receive(), app.mpris.Receive())
 		return nil
 	}
@@ -280,7 +272,6 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 			Debugf("initializing zeroconf session")
 
 		apiCh = make(chan ApiRequest)
-		app.currentPlayer.Store(currentPlayer)
 		go currentPlayer.Run(ctx, apiCh, app.mpris.Receive())
 
 		// let zeroconf know that we already have a user
@@ -293,7 +284,11 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 			select {
 			case req := <-app.server.Receive():
 				if currentPlayer == nil {
-					req.Reply(nil, ErrNoSession)
+					if req.Type == ApiRequestTypeRoot {
+						req.Reply(&ApiResponseRoot{}, nil)
+					} else {
+						req.Reply(nil, ErrNoSession)
+					}
 					break
 				}
 
@@ -313,7 +308,6 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 					continue
 				}
 
-				app.currentPlayer.Store(nil)
 				currentPlayer.Close()
 				currentPlayer = nil
 
@@ -336,7 +330,6 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 					apiCh = make(chan ApiRequest)
 					currentPlayer = newAppPlayer
 
-					app.currentPlayer.Store(newAppPlayer)
 					go newAppPlayer.Run(ctx, apiCh, app.mpris.Receive())
 
 					// let zeroconf know that we already have a user
@@ -351,7 +344,6 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 
 	return z.Serve(func(req zeroconf.NewUserRequest) bool {
 		if currentPlayer != nil {
-			app.currentPlayer.Store(nil)
 			currentPlayer.Close()
 			currentPlayer = nil
 
@@ -387,7 +379,6 @@ func (app *App) withAppPlayer(ctx context.Context, appPlayerFunc func(context.Co
 				Debugf("persisted zeroconf credentials")
 		}
 
-		app.currentPlayer.Store(newAppPlayer)
 		go newAppPlayer.Run(ctx, apiCh, app.mpris.Receive())
 		return true
 	})
@@ -599,7 +590,7 @@ func main() {
 
 	// create api server if needed
 	if cfg.Server.Enabled {
-		app.server, err = NewApiServer(app.log, cfg.Server.Address, cfg.Server.Port, cfg.Server.AllowOrigin, cfg.Server.CertFile, cfg.Server.KeyFile, app.playbackReady)
+		app.server, err = NewApiServer(app.log, cfg.Server.Address, cfg.Server.Port, cfg.Server.AllowOrigin, cfg.Server.CertFile, cfg.Server.KeyFile)
 		if err != nil {
 			log.WithError(err).Fatal("failed creating api server")
 		}

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/devgianlu/go-librespot/mpris"
@@ -45,10 +44,11 @@ type AppPlayer struct {
 	prodInfo    *ProductInfo
 	countryCode *string
 
-	hasSpotConnId          atomic.Bool
-	hasInitialConnectState atomic.Bool
-	hasCountryCode         atomic.Bool
-	playbackReadyEmitted   atomic.Bool
+	hasSpotConnId          bool
+	hasInitialConnectState bool
+	hasCountryCode         bool
+	playbackReadyCh        chan struct{}
+	playbackReadyOnce      sync.Once
 
 	state           *State
 	primaryStream   *player.Stream
@@ -58,13 +58,23 @@ type AppPlayer struct {
 }
 
 func (p *AppPlayer) playbackReady() bool {
-	return p.hasSpotConnId.Load() && p.hasInitialConnectState.Load() && p.hasCountryCode.Load()
+	select {
+	case <-p.playbackReadyCh:
+		return true
+	default:
+		return false
+	}
 }
 
 func (p *AppPlayer) notifyPlaybackReadyIfNeeded() {
-	if p.playbackReady() && p.playbackReadyEmitted.CompareAndSwap(false, true) {
-		p.app.server.Emit(&ApiEvent{Type: ApiEventTypePlaybackReady})
+	if !p.hasSpotConnId || !p.hasInitialConnectState || !p.hasCountryCode {
+		return
 	}
+
+	p.playbackReadyOnce.Do(func() {
+		close(p.playbackReadyCh)
+		p.app.server.Emit(&ApiEvent{Type: ApiEventTypePlaybackReady})
+	})
 }
 
 func (p *AppPlayer) handleAccesspointPacket(pktType ap.PacketType, payload []byte) error {
@@ -83,7 +93,7 @@ func (p *AppPlayer) handleAccesspointPacket(pktType ap.PacketType, payload []byt
 		return nil
 	case ap.PacketTypeCountryCode:
 		*p.countryCode = string(payload)
-		p.hasCountryCode.Store(true)
+		p.hasCountryCode = true
 		p.notifyPlaybackReadyIfNeeded()
 		return nil
 	default:
@@ -98,7 +108,7 @@ func (p *AppPlayer) handleDealerMessage(ctx context.Context, msg dealer.Message)
 
 	if strings.HasPrefix(msg.Uri, "hm://pusher/v1/connections/") {
 		p.spotConnId = msg.Headers["Spotify-Connection-Id"]
-		p.hasSpotConnId.Store(p.spotConnId != "")
+		p.hasSpotConnId = p.spotConnId != ""
 		p.app.log.Debugf("received connection id: %s...%s", p.spotConnId[:16], p.spotConnId[len(p.spotConnId)-16:])
 
 		// put the initial state
@@ -106,7 +116,7 @@ func (p *AppPlayer) handleDealerMessage(ctx context.Context, msg dealer.Message)
 			return fmt.Errorf("failed initial state put: %w", err)
 		}
 
-		p.hasInitialConnectState.Store(true)
+		p.hasInitialConnectState = true
 		p.notifyPlaybackReadyIfNeeded()
 
 		if !p.app.cfg.ExternalVolume && len(p.app.cfg.MixerDevice) == 0 {
@@ -399,6 +409,8 @@ func (p *AppPlayer) handleApiRequest(ctx context.Context, req ApiRequest) (any, 
 	defer cancel()
 
 	switch req.Type {
+	case ApiRequestTypeRoot:
+		return &ApiResponseRoot{PlaybackReady: p.playbackReady()}, nil
 	case ApiRequestTypeWebApi:
 		data := req.Data.(ApiRequestDataWebApi)
 		resp, err := p.sess.WebApi(ctx, data.Method, data.Path, data.Query, nil, nil)

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -48,6 +48,7 @@ type AppPlayer struct {
 	hasSpotConnId          atomic.Bool
 	hasInitialConnectState atomic.Bool
 	hasCountryCode         atomic.Bool
+	playbackReadyEmitted   atomic.Bool
 
 	state           *State
 	primaryStream   *player.Stream
@@ -58,6 +59,12 @@ type AppPlayer struct {
 
 func (p *AppPlayer) playbackReady() bool {
 	return p.hasSpotConnId.Load() && p.hasInitialConnectState.Load() && p.hasCountryCode.Load()
+}
+
+func (p *AppPlayer) notifyPlaybackReadyIfNeeded() {
+	if p.playbackReady() && p.playbackReadyEmitted.CompareAndSwap(false, true) {
+		p.app.server.Emit(&ApiEvent{Type: ApiEventTypePlaybackReady})
+	}
 }
 
 func (p *AppPlayer) handleAccesspointPacket(pktType ap.PacketType, payload []byte) error {
@@ -77,6 +84,7 @@ func (p *AppPlayer) handleAccesspointPacket(pktType ap.PacketType, payload []byt
 	case ap.PacketTypeCountryCode:
 		*p.countryCode = string(payload)
 		p.hasCountryCode.Store(true)
+		p.notifyPlaybackReadyIfNeeded()
 		return nil
 	default:
 		return nil
@@ -99,6 +107,7 @@ func (p *AppPlayer) handleDealerMessage(ctx context.Context, msg dealer.Message)
 		}
 
 		p.hasInitialConnectState.Store(true)
+		p.notifyPlaybackReadyIfNeeded()
 
 		if !p.app.cfg.ExternalVolume && len(p.app.cfg.MixerDevice) == 0 {
 			// update initial volume

--- a/cmd/daemon/player.go
+++ b/cmd/daemon/player.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/devgianlu/go-librespot/mpris"
@@ -44,11 +45,19 @@ type AppPlayer struct {
 	prodInfo    *ProductInfo
 	countryCode *string
 
+	hasSpotConnId          atomic.Bool
+	hasInitialConnectState atomic.Bool
+	hasCountryCode         atomic.Bool
+
 	state           *State
 	primaryStream   *player.Stream
 	secondaryStream *player.Stream
 
 	prefetchTimer *time.Timer
+}
+
+func (p *AppPlayer) playbackReady() bool {
+	return p.hasSpotConnId.Load() && p.hasInitialConnectState.Load() && p.hasCountryCode.Load()
 }
 
 func (p *AppPlayer) handleAccesspointPacket(pktType ap.PacketType, payload []byte) error {
@@ -67,6 +76,7 @@ func (p *AppPlayer) handleAccesspointPacket(pktType ap.PacketType, payload []byt
 		return nil
 	case ap.PacketTypeCountryCode:
 		*p.countryCode = string(payload)
+		p.hasCountryCode.Store(true)
 		return nil
 	default:
 		return nil
@@ -80,12 +90,15 @@ func (p *AppPlayer) handleDealerMessage(ctx context.Context, msg dealer.Message)
 
 	if strings.HasPrefix(msg.Uri, "hm://pusher/v1/connections/") {
 		p.spotConnId = msg.Headers["Spotify-Connection-Id"]
+		p.hasSpotConnId.Store(p.spotConnId != "")
 		p.app.log.Debugf("received connection id: %s...%s", p.spotConnId[:16], p.spotConnId[len(p.spotConnId)-16:])
 
 		// put the initial state
 		if err := p.putConnectState(ctx, connectpb.PutStateReason_NEW_DEVICE); err != nil {
 			return fmt.Errorf("failed initial state put: %w", err)
 		}
+
+		p.hasInitialConnectState.Store(true)
 
 		if !p.app.cfg.ExternalVolume && len(p.app.cfg.MixerDevice) == 0 {
 			// update initial volume


### PR DESCRIPTION
While trying to test the `/player/play` endpoint. I ran into a bug where the app would say that "its up" ( GET "/" and "/status" would return 200) but when i hit the `/player/play` endpoint, the playback would fail.

sometimes the connection id was not set, sometimes the volume sync hadn't happened, which led to the volume of the track changing mid playback.

So i had to expose a `playback_ready` field that is set to `true` whenever its safe to call `/player/play` and `false` otherwise