### PR TITLE
fix: unify client shutdown around access point and dealer lifecycles

### DIFF
--- a/ap/ap.go
+++ b/ap/ap.go
@@ -51,15 +51,12 @@ type Accesspoint struct {
 	conn    net.Conn
 	encConn *shannonConn
 
-	closed            bool
-	stop              bool
-	pongAckTickerStop chan struct{}
-	recvLoopStop      chan struct{}
-	recvLoopOnce      sync.Once
-	recvChans         map[PacketType][]chan Packet
-	recvChansLock     sync.RWMutex
-	lastPongAck       time.Time
-	lastPongAckLock   sync.Mutex
+	done            chan struct{}
+	recvLoopOnce    sync.Once
+	recvChans       map[PacketType][]chan Packet
+	recvChansLock   sync.RWMutex
+	lastPongAck     time.Time
+	lastPongAckLock sync.Mutex
 
 	// connMu is held for writing when performing reconnection and for reading mainly when accessing welcome
 	// or sending packets. If it's not held, a valid connection (and APWelcome) is available. Be careful not to deadlock
@@ -70,13 +67,16 @@ type Accesspoint struct {
 
 func NewAccesspoint(log librespot.Logger, addr librespot.GetAddressFunc, deviceId string) *Accesspoint {
 	return &Accesspoint{
-		log:               log,
-		addr:              addr,
-		deviceId:          deviceId,
-		pongAckTickerStop: make(chan struct{}, 1),
-		recvLoopStop:      make(chan struct{}, 1),
-		recvChans:         make(map[PacketType][]chan Packet),
+		log:       log,
+		addr:      addr,
+		deviceId:  deviceId,
+		done:      make(chan struct{}),
+		recvChans: make(map[PacketType][]chan Packet),
 	}
+}
+
+func (ap *Accesspoint) Done() <-chan struct{} {
+	return ap.done
 }
 
 func (ap *Accesspoint) init(ctx context.Context) (err error) {
@@ -197,8 +197,10 @@ func (ap *Accesspoint) Connect(ctx context.Context, creds *pb.LoginCredentials) 
 	ap.connMu.Lock()
 	defer ap.connMu.Unlock()
 
-	if ap.closed {
+	select {
+	case <-ap.done:
 		return ErrAccesspointClosed
+	default:
 	}
 
 	return backoff.Retry(func() error {
@@ -242,19 +244,26 @@ func (ap *Accesspoint) connect(ctx context.Context, creds *pb.LoginCredentials) 
 
 func (ap *Accesspoint) Close() {
 	ap.connMu.Lock()
-	ap.closed = true
-	ap.stop = true
-	ap.signalStop()
+	defer ap.connMu.Unlock()
+
+	select {
+	case <-ap.done:
+		return
+	default:
+	}
+
+	close(ap.done)
 	ap.closeConnLocked()
-	ap.connMu.Unlock()
 }
 
 func (ap *Accesspoint) Send(ctx context.Context, pktType PacketType, payload []byte) error {
 	ap.connMu.RLock()
 	defer ap.connMu.RUnlock()
 
-	if ap.closed {
+	select {
+	case <-ap.done:
 		return ErrAccesspointClosed
+	default:
 	}
 
 	return ap.encConn.sendPacket(ctx, pktType, payload)
@@ -263,10 +272,12 @@ func (ap *Accesspoint) Send(ctx context.Context, pktType PacketType, payload []b
 func (ap *Accesspoint) Receive(types ...PacketType) <-chan Packet {
 	ch := make(chan Packet)
 	ap.connMu.RLock()
-	if ap.closed {
+	select {
+	case <-ap.done:
 		ap.connMu.RUnlock()
 		close(ch)
 		return ch
+	default:
 	}
 
 	ap.recvChansLock.Lock()
@@ -297,13 +308,15 @@ func (ap *Accesspoint) recvLoop() {
 loop:
 	for {
 		select {
-		case <-ap.recvLoopStop:
+		case <-ap.done:
 			break loop
 		default:
 			// no need to hold the connMu since reconnection happens in this routine
 			pkt, payload, err := ap.encConn.receivePacket(context.TODO())
 			if err != nil {
-				if !ap.isStopped() {
+				select {
+				case <-ap.done:
+				default:
 					ap.log.WithError(err).Errorf("failed receiving packet")
 				}
 
@@ -342,8 +355,9 @@ loop:
 	// always close as we might end up here because of application errors
 	ap.closeConn()
 
-	// if we shouldn't stop, try to reconnect
-	if !ap.isStopped() {
+	select {
+	case <-ap.done:
+	default:
 		ap.connMu.Lock()
 		if err := backoff.Retry(ap.reconnect, backoff.NewExponentialBackOff()); err != nil {
 			ap.log.WithError(err).Errorf("failed reconnecting accesspoint")
@@ -351,11 +365,12 @@ loop:
 
 			// something went very wrong, give up
 			ap.Close()
-		}
-		ap.connMu.Unlock()
+		} else {
+			ap.connMu.Unlock()
 
-		// reconnection was successful, do not close receivers
-		return
+			// reconnection was successful, do not close receivers
+			return
+		}
 	}
 
 	ap.recvChansLock.RLock()
@@ -379,7 +394,7 @@ func (ap *Accesspoint) pongAckTicker() {
 loop:
 	for {
 		select {
-		case <-ap.pongAckTickerStop:
+		case <-ap.done:
 			break loop
 		case <-ticker.C:
 			timePassed := ap.timeSinceLastPongAck()
@@ -447,24 +462,6 @@ func (ap *Accesspoint) closeConnLocked() {
 	if ap.conn != nil {
 		_ = ap.conn.Close()
 	}
-}
-
-func (ap *Accesspoint) signalStop() {
-	select {
-	case ap.recvLoopStop <- struct{}{}:
-	default:
-	}
-
-	select {
-	case ap.pongAckTickerStop <- struct{}{}:
-	default:
-	}
-}
-
-func (ap *Accesspoint) isStopped() bool {
-	ap.connMu.RLock()
-	defer ap.connMu.RUnlock()
-	return ap.stop
 }
 
 func (ap *Accesspoint) performKeyExchange() ([]byte, error) {

--- a/ap/ap.go
+++ b/ap/ap.go
@@ -52,15 +52,14 @@ type Accesspoint struct {
 	encConn *shannonConn
 
 	done            chan struct{}
+	closeOnce       sync.Once
 	recvLoopOnce    sync.Once
 	recvChans       map[PacketType][]chan Packet
 	recvChansLock   sync.RWMutex
 	lastPongAck     time.Time
 	lastPongAckLock sync.Mutex
 
-	// connMu is held for writing when performing reconnection and for reading mainly when accessing welcome
-	// or sending packets. If it's not held, a valid connection (and APWelcome) is available. Be careful not to deadlock
-	// anything with this.
+	// connMu protects conn, encConn, and welcome pointer state.
 	connMu  sync.RWMutex
 	welcome *pb.APWelcome
 }
@@ -243,30 +242,34 @@ func (ap *Accesspoint) connect(ctx context.Context, creds *pb.LoginCredentials) 
 }
 
 func (ap *Accesspoint) Close() {
-	ap.connMu.Lock()
-	defer ap.connMu.Unlock()
-
-	select {
-	case <-ap.done:
-		return
-	default:
-	}
-
-	close(ap.done)
-	ap.closeConnLocked()
+	ap.closeOnce.Do(func() {
+		close(ap.done)
+		ap.closeConn()
+	})
 }
 
 func (ap *Accesspoint) Send(ctx context.Context, pktType PacketType, payload []byte) error {
 	ap.connMu.RLock()
-	defer ap.connMu.RUnlock()
-
 	select {
 	case <-ap.done:
+		ap.connMu.RUnlock()
 		return ErrAccesspointClosed
 	default:
 	}
 
-	return ap.encConn.sendPacket(ctx, pktType, payload)
+	encConn := ap.encConn
+	ap.connMu.RUnlock()
+
+	if err := encConn.sendPacket(ctx, pktType, payload); err != nil {
+		select {
+		case <-ap.done:
+			return ErrAccesspointClosed
+		default:
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (ap *Accesspoint) Receive(types ...PacketType) <-chan Packet {
@@ -453,14 +456,12 @@ func (ap *Accesspoint) timeSinceLastPongAck() time.Duration {
 }
 
 func (ap *Accesspoint) closeConn() {
-	ap.connMu.Lock()
-	ap.closeConnLocked()
-	ap.connMu.Unlock()
-}
+	ap.connMu.RLock()
+	conn := ap.conn
+	ap.connMu.RUnlock()
 
-func (ap *Accesspoint) closeConnLocked() {
-	if ap.conn != nil {
-		_ = ap.conn.Close()
+	if conn != nil {
+		_ = conn.Close()
 	}
 }
 

--- a/ap/ap_test.go
+++ b/ap/ap_test.go
@@ -67,63 +67,54 @@ func (c *blockingConn) Close() error {
 	return nil
 }
 
-func TestPongAckTickerDoesNotPanicWhenConnNil(t *testing.T) {
+func TestPongAckTickerStopsWhenConnNil(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ap := NewAccesspoint(&librespot.NullLogger{}, nil, "")
+		stopped := make(chan struct{})
 
-		panicCh := make(chan any, 1)
 		go func() {
-			defer func() {
-				panicCh <- recover()
-			}()
+			defer close(stopped)
 			ap.pongAckTicker()
 		}()
 
 		time.Sleep(pongAckInterval + time.Nanosecond)
 		synctest.Wait()
 
-		select {
-		case p := <-panicCh:
-			if p != nil {
-				t.Fatalf("pongAckTicker panicked when conn was nil: %v", p)
-			}
-		default:
-		}
-
-		ap.pongAckTickerStop <- struct{}{}
+		ap.Close()
 		synctest.Wait()
 
 		select {
-		case p := <-panicCh:
-			if p != nil {
-				t.Fatalf("pongAckTicker panicked when conn was nil: %v", p)
-			}
+		case <-stopped:
 		default:
 			t.Fatal("pongAckTicker did not stop")
 		}
 	})
 }
 
-func TestCloseStopsPongAckTickerWhenConnNil(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		ap := NewAccesspoint(&librespot.NullLogger{}, nil, "")
-		done := make(chan struct{})
+func TestDoneChannelClosesOnClose(t *testing.T) {
+	ap := NewAccesspoint(&librespot.NullLogger{}, nil, "")
 
-		go func() {
-			defer close(done)
-			ap.pongAckTicker()
-		}()
+	select {
+	case <-ap.Done():
+		t.Fatal("done channel should remain open before Close")
+	default:
+	}
 
-		synctest.Wait()
-		ap.Close()
-		synctest.Wait()
+	ap.Close()
 
-		select {
-		case <-done:
-		default:
-			t.Fatal("pongAckTicker did not stop when closing with nil conn")
-		}
-	})
+	select {
+	case <-ap.Done():
+	default:
+		t.Fatal("done channel did not close")
+	}
+
+	ap.Close()
+
+	select {
+	case <-ap.Done():
+	default:
+		t.Fatal("done channel should stay closed after repeated Close")
+	}
 }
 
 func TestCloseWaitsForInFlightSend(t *testing.T) {

--- a/ap/ap_test.go
+++ b/ap/ap_test.go
@@ -2,9 +2,9 @@ package ap
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
-	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -17,36 +17,15 @@ type stubAddr string
 func (a stubAddr) Network() string { return string(a) }
 func (a stubAddr) String() string  { return string(a) }
 
-type countingConn struct {
-	mu     sync.Mutex
-	closes int
-}
-
-func (c *countingConn) Read([]byte) (int, error)         { return 0, io.EOF }
-func (c *countingConn) Write(b []byte) (int, error)      { return len(b), nil }
-func (c *countingConn) Close() error                     { c.mu.Lock(); c.closes++; c.mu.Unlock(); return nil }
-func (c *countingConn) LocalAddr() net.Addr              { return stubAddr("local") }
-func (c *countingConn) RemoteAddr() net.Addr             { return stubAddr("remote") }
-func (c *countingConn) SetDeadline(time.Time) error      { return nil }
-func (c *countingConn) SetReadDeadline(time.Time) error  { return nil }
-func (c *countingConn) SetWriteDeadline(time.Time) error { return nil }
-
-func (c *countingConn) CloseCount() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.closes
-}
-
 type blockingConn struct {
-	started sync.Once
-	startCh chan struct{}
-	blockCh chan struct{}
+	startCh  chan struct{}
+	closedCh chan struct{}
 }
 
 func newBlockingConn() *blockingConn {
 	return &blockingConn{
-		startCh: make(chan struct{}),
-		blockCh: make(chan struct{}),
+		startCh:  make(chan struct{}),
+		closedCh: make(chan struct{}),
 	}
 }
 
@@ -57,13 +36,14 @@ func (c *blockingConn) SetDeadline(time.Time) error      { return nil }
 func (c *blockingConn) SetReadDeadline(time.Time) error  { return nil }
 func (c *blockingConn) SetWriteDeadline(time.Time) error { return nil }
 
-func (c *blockingConn) Write(b []byte) (int, error) {
-	c.started.Do(func() { close(c.startCh) })
-	<-c.blockCh
-	return len(b), nil
+func (c *blockingConn) Write([]byte) (int, error) {
+	close(c.startCh)
+	<-c.closedCh
+	return 0, io.ErrClosedPipe
 }
 
 func (c *blockingConn) Close() error {
+	close(c.closedCh)
 	return nil
 }
 
@@ -117,7 +97,7 @@ func TestDoneChannelClosesOnClose(t *testing.T) {
 	}
 }
 
-func TestCloseWaitsForInFlightSend(t *testing.T) {
+func TestCloseSignalsAndUnblocksInFlightSend(t *testing.T) {
 	conn := newBlockingConn()
 	ap := NewAccesspoint(&librespot.NullLogger{}, nil, "")
 	ap.conn = conn
@@ -141,25 +121,23 @@ func TestCloseWaitsForInFlightSend(t *testing.T) {
 	}()
 
 	select {
-	case <-closeDone:
-		t.Fatal("close returned before in-flight send finished")
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	close(conn.blockCh)
-
-	select {
-	case err := <-sendDone:
-		if err != nil {
-			t.Fatalf("send error = %v", err)
-		}
+	case <-ap.Done():
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for send to finish")
+		t.Fatal("timed out waiting for done channel to close")
 	}
 
 	select {
 	case <-closeDone:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for close to finish")
+	}
+
+	select {
+	case err := <-sendDone:
+		if !errors.Is(err, ErrAccesspointClosed) {
+			t.Fatalf("expected ErrAccesspointClosed, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for send to finish")
 	}
 }

--- a/audio/provider.go
+++ b/audio/provider.go
@@ -27,8 +27,7 @@ type KeyProvider struct {
 
 	recvLoopOnce sync.Once
 
-	reqChan  chan keyRequest
-	stopChan chan struct{}
+	reqChan chan keyRequest
 }
 
 type keyRequest struct {
@@ -45,7 +44,6 @@ type keyResponse struct {
 func NewAudioKeyProvider(log librespot.Logger, ap *ap.Accesspoint) *KeyProvider {
 	p := &KeyProvider{log: log, ap: ap}
 	p.reqChan = make(chan keyRequest)
-	p.stopChan = make(chan struct{}, 1)
 	return p
 }
 
@@ -55,16 +53,20 @@ func (p *KeyProvider) startReceiving() {
 
 func (p *KeyProvider) recvLoop() {
 	ch := p.ap.Receive(ap.PacketTypeAesKey, ap.PacketTypeAesKeyError)
+	done := p.ap.Done()
 
 	seq := uint32(0)
 	reqs := map[uint32]keyRequest{}
 
 	for {
 		select {
-		case <-p.stopChan:
-			p.stopChan <- struct{}{}
+		case <-done:
 			return
-		case pkt := <-ch:
+		case pkt, ok := <-ch:
+			if !ok {
+				return
+			}
+
 			resp := bytes.NewReader(pkt.Payload)
 			var respSeq uint32
 			_ = binary.Read(resp, binary.BigEndian, &respSeq)
@@ -114,27 +116,32 @@ func (p *KeyProvider) recvLoop() {
 }
 
 func (p *KeyProvider) Request(ctx context.Context, gid []byte, fileId []byte) ([]byte, error) {
+	done := p.ap.Done()
+
 	p.startReceiving()
 
 	req := keyRequest{gid: gid, fileId: fileId, resp: make(chan keyResponse, 1)}
-	p.reqChan <- req
+	select {
+	case <-done:
+		return nil, ap.ErrAccesspointClosed
+	case p.reqChan <- req:
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
+	var resp keyResponse
 	select {
+	case resp = <-req.resp:
 	case <-ctx.Done():
-		return nil, context.DeadlineExceeded
-	case resp := <-req.resp:
-		if resp.err != nil {
-			return nil, resp.err
-		}
-
-		return resp.key, nil
+		return nil, ctx.Err()
+	case <-done:
+		return nil, ap.ErrAccesspointClosed
 	}
-}
 
-func (p *KeyProvider) Close() {
-	p.stopChan <- struct{}{}
-	<-p.stopChan
+	if resp.err != nil {
+		return nil, resp.err
+	}
+
+	return resp.key, nil
 }

--- a/audio/provider_test.go
+++ b/audio/provider_test.go
@@ -1,0 +1,22 @@
+package audio
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	librespot "github.com/devgianlu/go-librespot"
+	"github.com/devgianlu/go-librespot/ap"
+)
+
+func TestRequestFailsWhenAccesspointIsClosed(t *testing.T) {
+	accesspoint := ap.NewAccesspoint(&librespot.NullLogger{}, nil, "")
+	accesspoint.Close()
+
+	provider := NewAudioKeyProvider(&librespot.NullLogger{}, accesspoint)
+
+	_, err := provider.Request(context.Background(), nil, nil)
+	if !errors.Is(err, ap.ErrAccesspointClosed) {
+		t.Fatalf("expected ErrAccesspointClosed, got %v", err)
+	}
+}

--- a/dealer/dealer.go
+++ b/dealer/dealer.go
@@ -32,13 +32,10 @@ type Dealer struct {
 
 	conn *websocket.Conn
 
-	closed         bool
-	stop           bool
-	pingTickerStop chan struct{}
-	recvLoopStop   chan struct{}
-	recvLoopOnce   sync.Once
-	lastPong       time.Time
-	lastPongLock   sync.Mutex
+	done         chan struct{}
+	recvLoopOnce sync.Once
+	lastPong     time.Time
+	lastPongLock sync.Mutex
 
 	// connMu is held for writing when performing reconnection and for reading when accessing the conn.
 	// If it's not held, a valid connection is available. Be careful not to deadlock anything with this.
@@ -62,8 +59,7 @@ func NewDealer(log librespot.Logger, client *http.Client, dealerAddr librespot.G
 		log:              log,
 		addr:             dealerAddr,
 		accessToken:      accessToken,
-		pingTickerStop:   make(chan struct{}, 1),
-		recvLoopStop:     make(chan struct{}, 1),
+		done:             make(chan struct{}),
 		requestReceivers: map[string]requestReceiver{},
 	}
 }
@@ -72,11 +68,13 @@ func (d *Dealer) Connect(ctx context.Context) error {
 	d.connMu.Lock()
 	defer d.connMu.Unlock()
 
-	if d.closed {
+	select {
+	case <-d.done:
 		return ErrDealerClosed
+	default:
 	}
 
-	if d.conn != nil && !d.stop {
+	if d.conn != nil {
 		d.log.Debugf("dealer connection already opened")
 		return nil
 	}
@@ -85,8 +83,6 @@ func (d *Dealer) Connect(ctx context.Context) error {
 }
 
 func (d *Dealer) connect(ctx context.Context) error {
-	d.stop = false
-
 	accessToken, err := d.accessToken(ctx, false)
 	if err != nil {
 		return fmt.Errorf("failed obtaining dealer access token: %w", err)
@@ -118,12 +114,16 @@ func (d *Dealer) connect(ctx context.Context) error {
 
 func (d *Dealer) Close() {
 	d.connMu.Lock()
-	d.closed = true
-	d.stop = true
+	select {
+	case <-d.done:
+		d.connMu.Unlock()
+		return
+	default:
+	}
+
+	close(d.done)
 	conn := d.conn
 	d.connMu.Unlock()
-
-	d.signalStop()
 
 	if conn != nil {
 		_ = conn.Close(websocket.StatusGoingAway, "")
@@ -132,7 +132,6 @@ func (d *Dealer) Close() {
 
 func (d *Dealer) startReceiving() {
 	d.recvLoopOnce.Do(func() {
-		d.clearStopSignals()
 		d.log.Tracef("starting dealer recv loop")
 		d.resetPongDeadline()
 		go d.pingTicker()
@@ -146,7 +145,7 @@ func (d *Dealer) pingTicker() {
 loop:
 	for {
 		select {
-		case <-d.pingTickerStop:
+		case <-d.done:
 			break loop
 		case <-ticker.C:
 			timePassed := d.timeSinceLastPong()
@@ -165,9 +164,10 @@ loop:
 			d.log.Tracef("sent dealer ping")
 
 			if err != nil {
-				if d.isStopped() {
-					// break early without logging if we should stop
+				select {
+				case <-d.done:
 					break loop
+				default:
 				}
 
 				d.log.WithError(err).Warnf("failed sending dealer ping")
@@ -187,17 +187,23 @@ func (d *Dealer) recvLoop() {
 loop:
 	for {
 		select {
-		case <-d.recvLoopStop:
+		case <-d.done:
 			break loop
 		default:
 			// no need to hold the connMu since reconnection happens in this routine
 			msgType, messageBytes, err := d.readConn(context.Background())
 
-			// don't log closed error if we're stopping
-			if d.isStopped() && websocket.CloseStatus(err) == websocket.StatusGoingAway {
-				d.log.Debugf("dealer connection closed")
-				break loop
-			} else if err != nil {
+			// don't log closed error if we're shutting down
+			if err != nil {
+				select {
+				case <-d.done:
+					if websocket.CloseStatus(err) == websocket.StatusGoingAway {
+						d.log.Debugf("dealer connection closed")
+					}
+					break loop
+				default:
+				}
+
 				d.log.WithError(err).Errorf("failed receiving dealer message")
 				break loop
 			} else if msgType != websocket.MessageText {
@@ -237,8 +243,9 @@ loop:
 	// always close as we might end up here because of application errors
 	d.closeConn(websocket.StatusInternalError)
 
-	// if we shouldn't stop, try to reconnect
-	if !d.isStopped() {
+	select {
+	case <-d.done:
+	default:
 		d.connMu.Lock()
 		if err := backoff.Retry(d.reconnect, backoff.NewExponentialBackOff()); err != nil {
 			d.log.WithError(err).Errorf("failed reconnecting dealer")
@@ -330,9 +337,11 @@ func (d *Dealer) closeConnRef(conn *websocket.Conn, status websocket.StatusCode)
 func (d *Dealer) writeConn(ctx context.Context, typ websocket.MessageType, payload []byte) (*websocket.Conn, error) {
 	d.connMu.RLock()
 
-	if d.closed {
+	select {
+	case <-d.done:
 		d.connMu.RUnlock()
 		return nil, ErrDealerClosed
+	default:
 	}
 
 	conn := d.conn
@@ -357,34 +366,4 @@ func (d *Dealer) readConn(ctx context.Context) (websocket.MessageType, []byte, e
 	}
 
 	return conn.Read(ctx)
-}
-
-func (d *Dealer) signalStop() {
-	select {
-	case d.recvLoopStop <- struct{}{}:
-	default:
-	}
-
-	select {
-	case d.pingTickerStop <- struct{}{}:
-	default:
-	}
-}
-
-func (d *Dealer) clearStopSignals() {
-	select {
-	case <-d.recvLoopStop:
-	default:
-	}
-
-	select {
-	case <-d.pingTickerStop:
-	default:
-	}
-}
-
-func (d *Dealer) isStopped() bool {
-	d.connMu.RLock()
-	defer d.connMu.RUnlock()
-	return d.stop
 }

--- a/dealer/dealer.go
+++ b/dealer/dealer.go
@@ -33,12 +33,12 @@ type Dealer struct {
 	conn *websocket.Conn
 
 	done         chan struct{}
+	closeOnce    sync.Once
 	recvLoopOnce sync.Once
 	lastPong     time.Time
 	lastPongLock sync.Mutex
 
-	// connMu is held for writing when performing reconnection and for reading when accessing the conn.
-	// If it's not held, a valid connection is available. Be careful not to deadlock anything with this.
+	// connMu protects conn pointer state.
 	connMu sync.RWMutex
 
 	messageReceivers     []messageReceiver
@@ -113,21 +113,10 @@ func (d *Dealer) connect(ctx context.Context) error {
 }
 
 func (d *Dealer) Close() {
-	d.connMu.Lock()
-	select {
-	case <-d.done:
-		d.connMu.Unlock()
-		return
-	default:
-	}
-
-	close(d.done)
-	conn := d.conn
-	d.connMu.Unlock()
-
-	if conn != nil {
-		_ = conn.Close(websocket.StatusGoingAway, "")
-	}
+	d.closeOnce.Do(func() {
+		close(d.done)
+		d.closeConn(websocket.StatusGoingAway)
+	})
 }
 
 func (d *Dealer) startReceiving() {
@@ -336,7 +325,6 @@ func (d *Dealer) closeConnRef(conn *websocket.Conn, status websocket.StatusCode)
 
 func (d *Dealer) writeConn(ctx context.Context, typ websocket.MessageType, payload []byte) (*websocket.Conn, error) {
 	d.connMu.RLock()
-
 	select {
 	case <-d.done:
 		d.connMu.RUnlock()
@@ -345,14 +333,21 @@ func (d *Dealer) writeConn(ctx context.Context, typ websocket.MessageType, paylo
 	}
 
 	conn := d.conn
+	d.connMu.RUnlock()
 
 	if conn == nil {
-		d.connMu.RUnlock()
 		return nil, fmt.Errorf("dealer connection not established")
 	}
 
 	err := conn.Write(ctx, typ, payload)
-	d.connMu.RUnlock()
+	if err != nil {
+		select {
+		case <-d.done:
+			return conn, ErrDealerClosed
+		default:
+		}
+	}
+
 	return conn, err
 }
 

--- a/dealer/dealer_test.go
+++ b/dealer/dealer_test.go
@@ -11,81 +11,36 @@ import (
 	librespot "github.com/devgianlu/go-librespot"
 )
 
-func TestPingTickerDoesNotPanicWhenConnNil(t *testing.T) {
+func TestPingTickerStopsWhenConnNil(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		d := &Dealer{
-			log:            &librespot.NullLogger{},
-			pingTickerStop: make(chan struct{}, 1),
+			log:  &librespot.NullLogger{},
+			done: make(chan struct{}),
 		}
+		stopped := make(chan struct{})
 
-		panicCh := make(chan any, 1)
 		go func() {
-			defer func() {
-				panicCh <- recover()
-			}()
+			defer close(stopped)
 			d.pingTicker()
 		}()
 
-		time.Sleep(pingInterval + timeout + time.Nanosecond)
+		time.Sleep(pingInterval + time.Nanosecond)
+		synctest.Wait()
+
+		d.Close()
 		synctest.Wait()
 
 		select {
-		case p := <-panicCh:
-			if p != nil {
-				t.Fatalf("pingTicker panicked when conn was nil: %v", p)
-			}
-		default:
-		}
-
-		d.pingTickerStop <- struct{}{}
-		synctest.Wait()
-
-		select {
-		case p := <-panicCh:
-			if p != nil {
-				t.Fatalf("pingTicker panicked when conn was nil: %v", p)
-			}
+		case <-stopped:
 		default:
 			t.Fatal("pingTicker did not stop")
 		}
 	})
 }
 
-func TestCloseStopsPingTickerWhenConnNil(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		d := &Dealer{
-			log:            &librespot.NullLogger{},
-			pingTickerStop: make(chan struct{}, 1),
-		}
-
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			d.pingTicker()
-		}()
-
-		synctest.Wait()
-		d.Close()
-		synctest.Wait()
-
-		stopped := false
-		select {
-		case <-done:
-			stopped = true
-		default:
-		}
-
-		d.pingTickerStop <- struct{}{}
-		synctest.Wait()
-
-		if !stopped {
-			t.Fatal("pingTicker did not stop when closing with nil conn")
-		}
-	})
-}
-
 func TestWriteConnRejectsClosedDealer(t *testing.T) {
-	d := &Dealer{closed: true}
+	d := &Dealer{done: make(chan struct{})}
+	close(d.done)
 
 	_, err := d.writeConn(context.Background(), websocket.MessageText, nil)
 	if !errors.Is(err, ErrDealerClosed) {

--- a/dealer/recv.go
+++ b/dealer/recv.go
@@ -188,11 +188,13 @@ func (d *Dealer) ReceiveMessage(uriPrefixes ...string) <-chan Message {
 	}
 
 	d.connMu.RLock()
-	if d.closed {
+	select {
+	case <-d.done:
 		d.connMu.RUnlock()
 		c := make(chan Message)
 		close(c)
 		return c
+	default:
 	}
 
 	d.messageReceiversLock.Lock()
@@ -231,28 +233,38 @@ func (d *Dealer) handleRequest(rawMsg *RawMessage) {
 	}
 
 	// dispatch request
-	resp := make(chan bool)
-	recv.c <- Request{
+	resp := make(chan bool, 1)
+	select {
+	case recv.c <- Request{
 		resp:         resp,
 		MessageIdent: rawMsg.MessageIdent,
 		Payload:      payload,
+	}:
+	case <-d.done:
+		return
 	}
 
 	// wait for response and send it
-	success := <-resp
-	if err := d.sendReply(rawMsg.Key, success); err != nil {
-		log.WithError(err).Error("failed sending dealer reply")
+	select {
+	case success := <-resp:
+		if err := d.sendReply(rawMsg.Key, success); err != nil {
+			log.WithError(err).Error("failed sending dealer reply")
+			return
+		}
+	case <-d.done:
 		return
 	}
 }
 
 func (d *Dealer) ReceiveRequest(uri string) <-chan Request {
 	d.connMu.RLock()
-	if d.closed {
+	select {
+	case <-d.done:
 		d.connMu.RUnlock()
 		c := make(chan Request)
 		close(c)
 		return c
+	default:
 	}
 
 	d.requestReceiversLock.Lock()

--- a/mercury/client.go
+++ b/mercury/client.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"sync"
+	"time"
+
 	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/ap"
 	spotifypb "github.com/devgianlu/go-librespot/proto/spotify"
 	"google.golang.org/protobuf/proto"
-	"sync"
-	"time"
 )
 
 type hermesRequest struct {
@@ -33,14 +34,12 @@ type Client struct {
 
 	recvLoopOnce sync.Once
 
-	reqChan  chan hermesRequest
-	stopChan chan struct{}
+	reqChan chan hermesRequest
 }
 
 func NewClient(log librespot.Logger, accesspoint *ap.Accesspoint) *Client {
 	c := &Client{log: log, ap: accesspoint}
 	c.reqChan = make(chan hermesRequest)
-	c.stopChan = make(chan struct{}, 1)
 	return c
 }
 
@@ -50,16 +49,20 @@ func (c *Client) startReceiving() {
 
 func (c *Client) recvLoop() {
 	ch := c.ap.Receive(ap.PacketTypeMercuryReq, ap.PacketTypeMercurySub, ap.PacketTypeMercuryUnsub, ap.PacketTypeMercuryEvent)
+	done := c.ap.Done()
 
 	seq := uint64(0)
 	reqs := map[uint64]hermesRequest{}
 
 	for {
 		select {
-		case <-c.stopChan:
-			c.stopChan <- struct{}{}
+		case <-done:
 			return
-		case pkt := <-ch:
+		case pkt, ok := <-ch:
+			if !ok {
+				return
+			}
+
 			if pkt.Type != ap.PacketTypeMercuryReq {
 				c.log.Warnf("skipping mercury packet with type: %s", pkt.Type.String())
 				continue
@@ -164,6 +167,8 @@ func (c *Client) recvLoop() {
 }
 
 func (c *Client) Request(ctx context.Context, method, uri string, fields map[string][]byte, payload []byte) ([]byte, error) {
+	done := c.ap.Done()
+
 	c.startReceiving()
 
 	header := &spotifypb.MercuryHeader{
@@ -185,33 +190,36 @@ func (c *Client) Request(ctx context.Context, method, uri string, fields map[str
 	}
 
 	req := hermesRequest{header: header, parts: parts, resp: make(chan hermesResponse, 1)}
-	c.reqChan <- req
+	select {
+	case <-done:
+		return nil, ap.ErrAccesspointClosed
+	case c.reqChan <- req:
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
+	var resp hermesResponse
 	select {
+	case resp = <-req.resp:
 	case <-ctx.Done():
-		return nil, context.DeadlineExceeded
-	case resp := <-req.resp:
-		if resp.err != nil {
-			return nil, resp.err
-		}
-
-		if *resp.header.StatusCode != 200 {
-			return nil, fmt.Errorf("mercury request failed with status code: %d", *resp.header.StatusCode)
-		}
-
-		var respPayload []byte
-		for _, part := range resp.parts {
-			respPayload = append(respPayload, part...)
-		}
-
-		return respPayload, nil
+		return nil, ctx.Err()
+	case <-done:
+		return nil, ap.ErrAccesspointClosed
 	}
-}
 
-func (c *Client) Close() {
-	c.stopChan <- struct{}{}
-	<-c.stopChan
+	if resp.err != nil {
+		return nil, resp.err
+	}
+
+	if *resp.header.StatusCode != 200 {
+		return nil, fmt.Errorf("mercury request failed with status code: %d", *resp.header.StatusCode)
+	}
+
+	var respPayload []byte
+	for _, part := range resp.parts {
+		respPayload = append(respPayload, part...)
+	}
+
+	return respPayload, nil
 }

--- a/mercury/client_test.go
+++ b/mercury/client_test.go
@@ -1,0 +1,22 @@
+package mercury
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	librespot "github.com/devgianlu/go-librespot"
+	"github.com/devgianlu/go-librespot/ap"
+)
+
+func TestRequestFailsWhenAccesspointIsClosed(t *testing.T) {
+	accesspoint := ap.NewAccesspoint(&librespot.NullLogger{}, nil, "")
+	accesspoint.Close()
+
+	client := NewClient(&librespot.NullLogger{}, accesspoint)
+
+	_, err := client.Request(context.Background(), "GET", "hm://test", nil, nil)
+	if !errors.Is(err, ap.ErrAccesspointClosed) {
+		t.Fatalf("expected ErrAccesspointClosed, got %v", err)
+	}
+}

--- a/session/session.go
+++ b/session/session.go
@@ -211,8 +211,6 @@ func NewSessionFromOptions(ctx context.Context, opts *Options) (*Session, error)
 
 func (s *Session) Close() {
 	s.events.Close()
-	s.audioKey.Close()
-	s.hg.Close()
 	s.dealer.Close()
 	s.ap.Close()
 }


### PR DESCRIPTION
Follow-up to #302 and #303. Those PRs hardened the lifecycle of ap and dealer themselves, but they. This PR is targeting a downstream issue from this, which is that mercury.Client and audio.KeyProvider have no way to observe when pa dies (which can cause some issues, as you might imagine).

The approach I took here is one I can adjust, but essentially the design does two things:
1. It makes ap the only things that truly closes
2. It gives ap a single done signal for consumers (like mercury and audio) to rely on

The main benefit of this design is that it simplifies the life cycle a lot (for instance, session close can now just rely on ap closing instead of having to deal with all the consumers too). 
The downside is that it is an API breaking change: mercury.Client.Close() and audio.KeyProvider.Close() are removed.

If you want to consider alternative designs, I am happy to do that. I have gone through some iterations on this, and in the end, I thought this was the cleanest.

General summary of the changes (🤖):
- Unifies shutdown handling in Accesspoint and Dealer by replacing ad-hoc stop/closed flags with a shared done channel lifecycle.
- Exposes Accesspoint.Done() and updates AP/dealer send/receive/reconnect loops to stop cleanly when shutting down.
- Makes audio.KeyProvider and mercury.Client follow the access point lifecycle instead of maintaining their own separate close/stop channels.
- Improves closed-state behavior for request/receive paths by returning ErrAccesspointClosed / ErrDealerClosed consistently and handling closed receiver channels safely.
- Simplifies Session.Close() by removing redundant explicit closes for audio key / mercury clients and relying on AP shutdown ownership.
- Adds regression tests covering clean ticker shutdown and request failures after the access point is closed.