### PR TITLE
docs(api): note that shuffle_context before play starts on a random track

### DIFF
--- a/api-spec.yml
+++ b/api-spec.yml
@@ -127,7 +127,12 @@ paths:
           description: Successful response
   /player/play:
     post:
-      description: Starts playing new content
+      description: >-
+        Starts playing new content. To start a context shuffled (on a random
+        track), enable shuffle first via /player/shuffle_context and then call
+        this. Calling /player/shuffle_context after play only shuffles the
+        upcoming queue and keeps the current (first) track, so play alone (or
+        shuffle after play) always begins on the context's first track.
       requestBody:
         $ref: '#/components/schemas/play'
       responses:
@@ -268,7 +273,10 @@ paths:
           description: Successful response
   /player/shuffle_context:
     post:
-      description: Toggle shuffling context
+      description: >-
+        Toggle shuffling the context. Enabling it BEFORE /player/play makes
+        playback start on a random track; enabling it after play only reshuffles
+        the upcoming queue and keeps the current (first) track.
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
### What

The HTTP API spec does not describe how to start a context shuffled (i.e. on a *random* first track). This adds that note to `/player/play` and `/player/shuffle_context`.

### Observed behaviour

- `POST /player/play {uri}` alone starts on the context's **first** track.
- `POST /player/shuffle_context {shuffle_context: true}` **after** play only randomizes the upcoming queue; the **current** track stays the first one.
- `POST /player/shuffle_context {shuffle_context: true}` **before** `POST /player/play {uri}` starts playback on a **random** track of the context.

Verified at runtime (armv7l): three consecutive `shuffle_context`-then-`play` calls each started on a different track.

### Change

Docs only: extends the `description` of `/player/play` and `/player/shuffle_context` in `api-spec.yml`. No code changes.