### PR TITLE
feat: add crossfade support between tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ audio_period_count: 4 # Number of periods to request, ALSA only
 audio_output_pipe: '' # Path to a named pipe for audio output
 audio_output_pipe_format: s16le # Audio output pipe format (s16le, s32le, f32le)
 bitrate: 160 # Playback bitrate (96, 160, 320)
+crossfade_duration: 0 # Crossfade duration between tracks in milliseconds (0 to disable)
 volume_steps: 100 # Volume steps count
 initial_volume: 100 # Initial volume in steps (not applied to the mixer device)
 ignore_last_volume: false # Whether to ignore the last saved volume and always use initial_volume

--- a/cmd/daemon/cli_config.go
+++ b/cmd/daemon/cli_config.go
@@ -51,6 +51,7 @@ type cliConfig struct {
 	NormalisationDisabled         bool     `koanf:"normalisation_disabled"`
 	NormalisationUseAlbumGain     bool     `koanf:"normalisation_use_album_gain"`
 	NormalisationPregain          float32  `koanf:"normalisation_pregain"`
+	CrossfadeDuration             int      `koanf:"crossfade_duration"`
 	ExternalVolume                bool     `koanf:"external_volume"`
 	ZeroconfEnabled               bool     `koanf:"zeroconf_enabled"`
 	ZeroconfPort                  int      `koanf:"zeroconf_port"`
@@ -110,6 +111,7 @@ func (c *cliConfig) toDaemonConfig() *daemon.Config {
 		NormalisationDisabled:     c.NormalisationDisabled,
 		NormalisationUseAlbumGain: c.NormalisationUseAlbumGain,
 		NormalisationPregain:      c.NormalisationPregain,
+		CrossfadeDuration:         c.CrossfadeDuration,
 		ExternalVolume:            c.ExternalVolume,
 		DisableAutoplay:           c.DisableAutoplay,
 

--- a/config_schema.json
+++ b/config_schema.json
@@ -281,6 +281,12 @@
           "description": "The normalisation pregain to apply to track/album normalisation factors",
           "default": 0
         },
+        "crossfade_duration": {
+          "type": "integer",
+          "description": "Crossfade duration between tracks in milliseconds, 0 to disable",
+          "default": 0,
+          "minimum": 0
+        },
         "external_volume": {
           "type": "boolean",
           "description": "Whether volume is controlled externally, if true the app will not pre-multiply samples",

--- a/daemon/app.go
+++ b/daemon/app.go
@@ -239,6 +239,8 @@ func (app *App) newAppPlayer(ctx context.Context, creds any) (_ *AppPlayer, err 
 		NormalisationUseAlbumGain: app.cfg.NormalisationUseAlbumGain,
 		NormalisationPregain:      app.cfg.NormalisationPregain,
 
+		CrossfadeDuration: time.Duration(app.cfg.CrossfadeDuration) * time.Millisecond,
+
 		CountryCode: appPlayer.countryCode,
 
 		AudioBackend:              app.cfg.AudioBackend,

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	NormalisationDisabled     bool
 	NormalisationUseAlbumGain bool
 	NormalisationPregain      float32
+	CrossfadeDuration         int
 	ExternalVolume            bool
 	DisableAutoplay           bool
 

--- a/daemon/controls.go
+++ b/daemon/controls.go
@@ -27,12 +27,22 @@ func (p *AppPlayer) prefetchNext(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	next := p.state.tracks.PeekNext(ctx)
-	if next == nil {
-		return
+	var nextUri string
+	if p.state.player.Options.RepeatingTrack {
+		// With repeat-track enabled the next thing to play is this same
+		// track again; prefetch it like any other upcoming track so the
+		// transition (including a crossfade) is seamless.
+		nextUri = p.state.player.Track.GetUri()
+	} else {
+		next := p.state.tracks.PeekNext(ctx)
+		if next == nil {
+			return
+		}
+
+		nextUri = next.Uri
 	}
 
-	if next.Uri == "" {
+	if nextUri == "" {
 		// It should be implemented some day (the ContextTrack has enough
 		// information to infer the track Uri) but it's hard to reproduce this
 		// issue.
@@ -40,9 +50,9 @@ func (p *AppPlayer) prefetchNext(ctx context.Context) {
 		return
 	}
 
-	nextId, err := librespot.SpotifyIdFromUri(next.Uri)
+	nextId, err := librespot.SpotifyIdFromUri(nextUri)
 	if err != nil {
-		p.app.log.WithError(err).WithField("uri", next.Uri).Warn("failed parsing prefetch uri")
+		p.app.log.WithError(err).WithField("uri", nextUri).Warn("failed parsing prefetch uri")
 		return
 	} else if p.secondaryStream != nil && p.secondaryStream.Is(*nextId) {
 		return
@@ -360,7 +370,11 @@ func (p *AppPlayer) loadCurrentTrack(ctx context.Context, paused, drop bool) err
 		p.secondaryStream = nil
 		prefetched = true
 	} else {
+		// The prefetched stream (if any) is not the track being loaded: clear
+		// it from the player too, so an upcoming track change cannot switch
+		// or fade into a stale stream.
 		p.secondaryStream = nil
+		p.player.SetSecondaryStream(nil)
 		prefetched = false
 
 		var err error
@@ -448,6 +462,12 @@ func (p *AppPlayer) setOptions(ctx context.Context, repeatingContext *bool, repe
 	}
 
 	if requiresUpdate {
+		// Repeat/shuffle changes alter which track comes next; a stream
+		// prefetched under the old plan must not be switched or faded into.
+		p.secondaryStream = nil
+		p.player.SetSecondaryStream(nil)
+		p.schedulePrefetchNext()
+
 		p.updateState(ctx)
 	}
 }
@@ -468,6 +488,11 @@ func (p *AppPlayer) addToQueue(ctx context.Context, track *connectpb.ContextTrac
 	p.state.player.PrevTracks = p.state.tracks.PrevTracks()
 	p.state.player.NextTracks = p.state.tracks.NextTracks(ctx, nil)
 	p.updateState(ctx)
+
+	// The queued track plays next: a stream prefetched under the old plan
+	// must not be switched or faded into.
+	p.secondaryStream = nil
+	p.player.SetSecondaryStream(nil)
 	p.schedulePrefetchNext()
 }
 
@@ -481,6 +506,11 @@ func (p *AppPlayer) setQueue(ctx context.Context, prev []*connectpb.ContextTrack
 	p.state.player.PrevTracks = p.state.tracks.PrevTracks()
 	p.state.player.NextTracks = p.state.tracks.NextTracks(ctx, next)
 	p.updateState(ctx)
+
+	// The upcoming track may have changed: a stream prefetched under the old
+	// plan must not be switched or faded into.
+	p.secondaryStream = nil
+	p.player.SetSecondaryStream(nil)
 	p.schedulePrefetchNext()
 }
 

--- a/player/player.go
+++ b/player/player.go
@@ -40,6 +40,7 @@ func ptr[T any](v T) *T {
 type Player struct {
 	log librespot.Logger
 
+	crossfadeSamples          int
 	flacEnabled               bool
 	normalisationEnabled      bool
 	normalisationUseAlbumGain bool
@@ -109,6 +110,10 @@ type Options struct {
 	// in dB. Use negative values to avoid clipping.
 	NormalisationPregain float32
 
+	// CrossfadeDuration specifies for how long tracks should overlap during
+	// a track change. Zero disables crossfading.
+	CrossfadeDuration time.Duration
+
 	// CountryCode specifies the country code to use for media restrictions.
 	CountryCode *string
 
@@ -165,6 +170,7 @@ type Options struct {
 func NewPlayer(opts *Options) (*Player, error) {
 	p := &Player{
 		log:                       opts.Log,
+		crossfadeSamples:          int(opts.CrossfadeDuration*SampleRate/time.Second) * Channels,
 		sp:                        opts.Spclient,
 		audioKey:                  opts.AudioKey,
 		events:                    opts.Events,
@@ -213,7 +219,7 @@ func (p *Player) manageLoop() {
 	volume := float32(1)
 
 	// init main source
-	source := NewSwitchingAudioSource()
+	source := NewSwitchingAudioSource(p.crossfadeSamples)
 
 loop:
 	for {

--- a/player/player.go
+++ b/player/player.go
@@ -583,6 +583,10 @@ func (p *Player) getUnrestrictedTrack(ctx context.Context, spotId librespot.Spot
 func (p *Player) NewStream(ctx context.Context, client *http.Client, spotId librespot.SpotifyId, bitrate int, mediaPosition int64) (*Stream, error) {
 	log := p.log.WithField("uri", spotId.Uri())
 
+	// Remember the id the caller asked for: spotId is reassigned below when a
+	// restricted track is relinked to an alternative.
+	requestedId := spotId
+
 	playbackId := make([]byte, 16)
 	_, _ = rand.Read(playbackId)
 
@@ -729,5 +733,5 @@ func (p *Player) NewStream(ctx context.Context, client *http.Client, spotId libr
 		}
 	}
 
-	return &Stream{PlaybackId: playbackId, Source: stream, Media: media, File: file}, nil
+	return &Stream{PlaybackId: playbackId, RequestedId: requestedId, Source: stream, Media: media, File: file}, nil
 }

--- a/player/source.go
+++ b/player/source.go
@@ -3,10 +3,22 @@ package player
 import (
 	"errors"
 	"io"
+	"math"
 	"sync"
 
 	librespot "github.com/devgianlu/go-librespot"
 )
+
+// maxSampleValue is the largest sample value that survives the int16 output
+// conversion without overflowing (32767/32768). Mixed samples are clamped to
+// [-1, maxSampleValue] so a crossfade can never wrap around to a click.
+const maxSampleValue = float32(0x7fff) / float32(0x8000)
+
+// lookaheadHeadroom is how many samples beyond the crossfade length are
+// buffered. Serving playback only from this headroom keeps a full crossfade
+// worth of audio in reserve, so the fade always has its complete length
+// available when the end of a track is discovered.
+const lookaheadHeadroom = 8 * 1024
 
 type SwitchingAudioSource struct {
 	source map[bool]librespot.AudioSource
@@ -16,20 +28,80 @@ type SwitchingAudioSource struct {
 	done chan struct{}
 
 	eofReported bool
+
+	// Crossfade state. When crossfadeSamples is zero the source behaves
+	// exactly as it did before crossfade support was introduced.
+	//
+	// While crossfading is enabled, audio is buffered ahead of playback in a
+	// ring buffer (buf) holding up to crossfadeSamples plus a small headroom.
+	// This lookahead is how the end of the primary source is discovered
+	// before it is audible: when the decoder returns EOF, the ring holds the
+	// track's tail. If a secondary source is available, the tail is faded out
+	// while the secondary fades in with equal-power gains.
+	crossfadeSamples int
+	buf              []float32 // lookahead ring, len == crossfadeSamples+lookaheadHeadroom
+	bufStart         int       // ring read index
+	bufLen           int       // samples currently buffered
+	primaryEOF       bool      // primary decoder returned EOF, ring holds its tail
+	pendingErr       error     // non-EOF read error, delivered once the ring drains
+	fading           bool      // mixing ring tail (fade out) with primary slot (fade in)
+	fadeTotal        int       // samples of tail at fade start, gain ramp length
+	fadePos          int       // samples of tail already mixed
+	scratch          []float32 // reusable buffer for fill and fade-in reads
 }
 
-func NewSwitchingAudioSource() *SwitchingAudioSource {
-	return &SwitchingAudioSource{
-		source: map[bool]librespot.AudioSource{},
-		cond:   sync.NewCond(&sync.Mutex{}),
-		done:   make(chan struct{}, 1),
+// NewSwitchingAudioSource creates an audio source that switches seamlessly
+// between a primary and a prefetched secondary source.
+//
+// If crossfadeSamples is greater than zero, track transitions overlap by up
+// to that many samples (interleaved, so frames times channels) with an
+// equal-power crossfade. A value of zero disables crossfading and preserves
+// gapless behavior.
+func NewSwitchingAudioSource(crossfadeSamples int) *SwitchingAudioSource {
+	if crossfadeSamples < 0 {
+		crossfadeSamples = 0
 	}
+
+	// Round down to a whole frame so channels never desynchronize.
+	crossfadeSamples -= crossfadeSamples % Channels
+
+	s := &SwitchingAudioSource{
+		source:           map[bool]librespot.AudioSource{},
+		cond:             sync.NewCond(&sync.Mutex{}),
+		done:             make(chan struct{}, 1),
+		crossfadeSamples: crossfadeSamples,
+	}
+
+	if crossfadeSamples > 0 {
+		s.buf = make([]float32, crossfadeSamples+lookaheadHeadroom)
+		s.scratch = make([]float32, 8*1024)
+	}
+
+	return s
 }
 
 func (s *SwitchingAudioSource) SetPrimary(source librespot.AudioSource) {
 	s.cond.L.Lock()
 	defer s.cond.L.Unlock()
-	s.source[s.which] = source
+
+	// After a crossfade begins, the incoming source has already been promoted
+	// to the primary slot. The daemon acknowledges the very same transition
+	// by re-setting the source it was told is now playing: that must not
+	// disturb the fade that is still in progress.
+	if s.source[s.which] != source {
+		// A genuinely new source replaces whatever was there, including any
+		// in-flight crossfade tail.
+		s.resetCrossfade()
+		s.source[s.which] = source
+	}
+
+	// If the same source was also prefetched into the secondary slot (e.g. a
+	// manual skip straight to the prefetched track), drop the alias: switching
+	// a source into itself would replay or fade into an exhausted stream.
+	if s.source[!s.which] == source {
+		delete(s.source, !s.which)
+	}
+
 	s.eofReported = false
 	s.cond.Broadcast()
 }
@@ -49,6 +121,15 @@ func (s *SwitchingAudioSource) Read(p []float32) (n int, err error) {
 	s.cond.L.Lock()
 	defer s.cond.L.Unlock()
 
+	if s.crossfadeSamples == 0 {
+		return s.readDirect(p)
+	}
+
+	return s.readCrossfade(p)
+}
+
+// readDirect is the original, crossfade-free read path.
+func (s *SwitchingAudioSource) readDirect(p []float32) (n int, err error) {
 	for s.source[s.which] == nil {
 		s.cond.Wait()
 	}
@@ -56,14 +137,7 @@ func (s *SwitchingAudioSource) Read(p []float32) (n int, err error) {
 	n, err = s.source[s.which].Read(p)
 	if errors.Is(err, io.EOF) {
 		// notify this source is done
-		if !s.eofReported {
-			s.eofReported = true
-
-			select {
-			case s.done <- struct{}{}:
-			default:
-			}
-		}
+		s.reportDone()
 
 		// if there's no other source just let the EOF through
 		if s.source[!s.which] == nil {
@@ -74,13 +148,237 @@ func (s *SwitchingAudioSource) Read(p []float32) (n int, err error) {
 		delete(s.source, s.which)
 		s.which = !s.which
 
-		// ignore the EOF, we have mode data
+		// ignore the EOF, we have more data
 		return n, nil
 	} else if err != nil {
 		return n, err
 	}
 
 	return n, nil
+}
+
+// readCrossfade is the read path used when crossfading is enabled. Playback
+// is served from a lookahead ring buffer so the end of the current track is
+// known before it is audible. While the track is still decoding, a full
+// crossfade worth of samples is kept in reserve and playback is served only
+// from the headroom above it, guaranteeing the complete fade length is
+// available the moment EOF is discovered.
+func (s *SwitchingAudioSource) readCrossfade(p []float32) (n int, err error) {
+	for {
+		if s.fading {
+			return s.readFade(p)
+		}
+
+		for s.source[s.which] == nil && !(s.primaryEOF && s.bufLen > 0) {
+			s.cond.Wait()
+		}
+
+		// Refill the lookahead with bounded reads. Decoders greedily fill
+		// whatever buffer they are handed, so reads are capped to keep each
+		// one short; playback is served as soon as anything is buffered and
+		// the ring keeps filling a little further on every call. Blocking
+		// here only happens when the ring is empty, matching the original
+		// path's behavior of blocking on a single source read.
+		budget := 2 * len(s.scratch)
+		for !s.primaryEOF && s.pendingErr == nil && s.bufLen < len(s.buf) &&
+			(s.bufLen == 0 || budget > 0) {
+			free := s.freeChunk()
+			free = free[:min(len(free), len(s.scratch))]
+			nn, err := s.source[s.which].Read(free)
+			s.bufLen += nn
+			budget -= nn
+			if errors.Is(err, io.EOF) {
+				// Frame-align defensively so a torn final frame cannot
+				// desynchronize channels during the fade.
+				s.bufLen -= s.bufLen % Channels
+				s.primaryEOF = true
+			} else if err != nil {
+				// Deliver buffered audio first; the error surfaces once the
+				// ring drains, mirroring how the original path returned data
+				// alongside errors.
+				s.pendingErr = err
+			}
+		}
+
+		if !s.primaryEOF && s.pendingErr == nil {
+			// While the track is still decoding, serve only the audio above
+			// the crossfade reserve. If the ring has not built up that far
+			// yet (right after a start or seek), serve from what exists so
+			// playback is never stalled; a track that ends this early simply
+			// gets a proportionally shorter fade.
+			limit := s.bufLen - s.crossfadeSamples
+			if limit <= 0 {
+				limit = min(s.bufLen, len(p))
+			}
+			return s.popChunk(p, limit), nil
+		}
+
+		if s.pendingErr != nil && !s.primaryEOF {
+			if s.bufLen > 0 {
+				return s.popChunk(p, s.bufLen), nil
+			}
+			err = s.pendingErr
+			s.pendingErr = nil
+			return 0, err
+		}
+
+		if s.source[!s.which] != nil {
+			// There is a next track. Any buffered audio beyond the fade
+			// length plays out plainly first.
+			if s.bufLen > s.crossfadeSamples {
+				return s.popChunk(p, s.bufLen-s.crossfadeSamples), nil
+			}
+
+			// Report the current track as done and promote the next one to
+			// the primary slot. The buffered tail fades out over it from the
+			// very next read.
+			s.reportDone()
+			delete(s.source, s.which)
+			s.which = !s.which
+			s.fading = true
+			s.fadeTotal = s.bufLen
+			s.fadePos = 0
+			continue
+		}
+
+		if s.bufLen == 0 {
+			// Tail fully drained and nobody to switch to: this is the end
+			// of playback, matching the original EOF timing.
+			s.reportDone()
+			return 0, io.EOF
+		}
+
+		// No next track (yet): keep draining the tail. A late prefetch can
+		// still upgrade this to a crossfade on a following read.
+		n = s.popChunk(p, s.bufLen)
+		if s.bufLen == 0 {
+			s.reportDone()
+			return n, io.EOF
+		}
+		return n, nil
+	}
+}
+
+// readFade mixes the buffered tail of the previous track (fading out) with
+// the already-promoted primary source (fading in) using equal-power gains.
+func (s *SwitchingAudioSource) readFade(p []float32) (n int, err error) {
+	want := min(len(p), s.fadeTotal-s.fadePos, len(s.scratch))
+	want -= want % Channels
+	if want <= 0 {
+		// Nothing left to mix (e.g. a zero-length tail).
+		s.finishFade()
+		return 0, nil
+	}
+
+	// Read the fade-in side. A short read simply mixes a shorter chunk; EOF
+	// means the next track is shorter than the fade, mix against silence and
+	// let the regular EOF handling deal with it once the tail is done.
+	var nIn int
+	if s.source[s.which] != nil {
+		nIn, err = s.source[s.which].Read(s.scratch[:want])
+		nIn -= nIn % Channels
+		if err != nil && !errors.Is(err, io.EOF) {
+			return 0, err
+		}
+	}
+
+	chunk := want
+	if nIn > 0 {
+		chunk = nIn
+	}
+
+	for i := 0; i < chunk; i += Channels {
+		// One gain per frame, cheap equal-power curves.
+		x := float64(s.fadePos+i) / float64(s.fadeTotal)
+		gainOut := float32(math.Cos(x * math.Pi / 2))
+		gainIn := float32(math.Sin(x * math.Pi / 2))
+
+		for c := 0; c < Channels; c++ {
+			sample := s.buf[(s.bufStart+i+c)%len(s.buf)] * gainOut
+			if i+c < nIn {
+				sample += s.scratch[i+c] * gainIn
+			}
+
+			// Clamp so the int16 output conversion cannot overflow.
+			if sample > maxSampleValue {
+				sample = maxSampleValue
+			} else if sample < -1 {
+				sample = -1
+			}
+
+			p[i+c] = sample
+		}
+	}
+
+	s.bufStart = (s.bufStart + chunk) % len(s.buf)
+	s.bufLen -= chunk
+	s.fadePos += chunk
+
+	if s.fadePos >= s.fadeTotal {
+		s.finishFade()
+	}
+
+	return chunk, nil
+}
+
+// finishFade clears all crossfade state, returning to normal lookahead
+// buffering of the (already promoted) primary source.
+func (s *SwitchingAudioSource) finishFade() {
+	s.fading = false
+	s.fadeTotal = 0
+	s.fadePos = 0
+	s.bufStart = 0
+	s.bufLen = 0
+	s.primaryEOF = false
+}
+
+// resetCrossfade drops any lookahead and fade state, for when the current
+// source is being replaced entirely (e.g. a manual skip).
+func (s *SwitchingAudioSource) resetCrossfade() {
+	if s.crossfadeSamples == 0 {
+		return
+	}
+
+	s.pendingErr = nil
+	s.finishFade()
+}
+
+// freeChunk returns the largest contiguous writable slice of the ring buffer.
+func (s *SwitchingAudioSource) freeChunk() []float32 {
+	start := (s.bufStart + s.bufLen) % len(s.buf)
+	end := min(start+(len(s.buf)-s.bufLen), len(s.buf))
+	return s.buf[start:end]
+}
+
+// popChunk copies up to limit buffered samples into p and consumes them from
+// the ring. The amount served is frame-aligned so the ring can never end up
+// on a torn frame.
+func (s *SwitchingAudioSource) popChunk(p []float32, limit int) (n int) {
+	want := min(len(p), limit, s.bufLen)
+	want -= want % Channels
+
+	for n < want {
+		end := min(s.bufStart+(want-n), len(s.buf)-s.bufStart+s.bufStart, s.bufStart+s.bufLen)
+		end = min(end, len(s.buf))
+		nn := copy(p[n:want], s.buf[s.bufStart:end])
+		s.bufStart = (s.bufStart + nn) % len(s.buf)
+		s.bufLen -= nn
+		n += nn
+	}
+	return n
+}
+
+func (s *SwitchingAudioSource) reportDone() {
+	if s.eofReported {
+		return
+	}
+
+	s.eofReported = true
+
+	select {
+	case s.done <- struct{}{}:
+	default:
+	}
 }
 
 func (s *SwitchingAudioSource) SetPositionMs(pos int64) error {
@@ -91,7 +389,22 @@ func (s *SwitchingAudioSource) SetPositionMs(pos int64) error {
 		return nil
 	}
 
-	return s.source[s.which].SetPositionMs(pos)
+	// Seeking invalidates both the lookahead and any fade in progress: the
+	// remains of the previous track are dropped and buffering restarts at
+	// the new position.
+	s.resetCrossfade()
+
+	if err := s.source[s.which].SetPositionMs(pos); err != nil {
+		return err
+	}
+
+	if s.crossfadeSamples > 0 {
+		// The crossfade path can discover EOF and report done well before the
+		// audio finishes; a seek revives the source, so re-arm the signal.
+		// The disabled path keeps the original behavior untouched.
+		s.eofReported = false
+	}
+	return nil
 }
 
 func (s *SwitchingAudioSource) PositionMs() int64 {
@@ -102,7 +415,18 @@ func (s *SwitchingAudioSource) PositionMs() int64 {
 		return 0
 	}
 
-	return s.source[s.which].PositionMs()
+	pos := s.source[s.which].PositionMs()
+	if s.crossfadeSamples > 0 && !s.fading {
+		// The decoder runs ahead of playback by the buffered lookahead,
+		// report where the listener actually is. While fading, the primary
+		// slot holds the incoming track which has no lookahead yet.
+		pos -= int64(s.bufLen / Channels * 1000 / SampleRate)
+		if pos < 0 {
+			pos = 0
+		}
+	}
+
+	return pos
 }
 
 func (s *SwitchingAudioSource) Close() error {

--- a/player/source_test.go
+++ b/player/source_test.go
@@ -1,0 +1,740 @@
+package player
+
+import (
+	"errors"
+	"io"
+	"math"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeSource is a deterministic AudioSource for exercising
+// SwitchingAudioSource. Samples are served from a slice in chunks of at most
+// maxRead samples per call.
+type fakeSource struct {
+	mu      sync.Mutex
+	samples []float32
+	pos     int
+	maxRead int
+	// eofWithLastRead makes the final Read return (n>0, io.EOF) together,
+	// mirroring sources that report EOF alongside the last chunk.
+	eofWithLastRead bool
+	// failAt injects failErr once pos reaches it (non-EOF error paths).
+	failAt  int
+	failErr error
+}
+
+func (f *fakeSource) Read(p []float32) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.failErr != nil && f.pos >= f.failAt {
+		return 0, f.failErr
+	}
+
+	remaining := len(f.samples) - f.pos
+	if remaining == 0 {
+		return 0, io.EOF
+	}
+
+	n := min(len(p), remaining)
+	if f.failErr != nil {
+		n = min(n, f.failAt-f.pos)
+	}
+	if f.maxRead > 0 {
+		n = min(n, f.maxRead)
+	}
+
+	copy(p, f.samples[f.pos:f.pos+n])
+	f.pos += n
+
+	if f.eofWithLastRead && f.pos == len(f.samples) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (f *fakeSource) SetPositionMs(pos int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pos = int(pos) * SampleRate / 1000 * Channels
+	return nil
+}
+
+func (f *fakeSource) PositionMs() int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return int64(f.pos / Channels * 1000 / SampleRate)
+}
+
+// constSource builds a fake source of n samples all set to value v.
+func constSource(n int, v float32, maxRead int) *fakeSource {
+	samples := make([]float32, n)
+	for i := range samples {
+		samples[i] = v
+	}
+	return &fakeSource{samples: samples, maxRead: maxRead}
+}
+
+// rampSource builds a fake source whose sample i has value base+i, making
+// positions recognizable in the output.
+func rampSource(n int, base float32, maxRead int) *fakeSource {
+	samples := make([]float32, n)
+	for i := range samples {
+		samples[i] = base + float32(i)
+	}
+	return &fakeSource{samples: samples, maxRead: maxRead}
+}
+
+// readUntilEOF drains the source with the given read chunk size.
+func readUntilEOF(t *testing.T, s *SwitchingAudioSource, chunk int) []float32 {
+	t.Helper()
+	var out []float32
+	buf := make([]float32, chunk)
+	for i := 0; ; i++ {
+		if i > 1_000_000 {
+			t.Fatal("readUntilEOF: too many iterations, EOF never surfaced")
+		}
+		n, err := s.Read(buf)
+		out = append(out, buf[:n]...)
+		if err == io.EOF {
+			return out
+		} else if err != nil {
+			t.Fatalf("unexpected read error: %v", err)
+		}
+	}
+}
+
+// readUntilFading consumes audio until the crossfade engages.
+func readUntilFading(t *testing.T, s *SwitchingAudioSource, chunk int) (consumed int) {
+	t.Helper()
+	buf := make([]float32, chunk)
+	for i := 0; ; i++ {
+		if i > 1_000_000 {
+			t.Fatal("readUntilFading: fade never engaged")
+		}
+		s.cond.L.Lock()
+		fading := s.fading
+		s.cond.L.Unlock()
+		if fading {
+			return consumed
+		}
+		n, err := s.Read(buf)
+		if err != nil {
+			t.Fatalf("unexpected error while waiting for fade: %v", err)
+		}
+		consumed += n
+	}
+}
+
+// expectDone asserts the done channel has fired.
+func expectDone(t *testing.T, s *SwitchingAudioSource) {
+	t.Helper()
+	select {
+	case <-s.Done():
+	case <-time.After(time.Second):
+		t.Fatal("done channel did not fire")
+	}
+}
+
+func expectNotDone(t *testing.T, s *SwitchingAudioSource) {
+	t.Helper()
+	select {
+	case <-s.Done():
+		t.Fatal("done channel fired unexpectedly")
+	default:
+	}
+}
+
+func TestDirectPassthroughDisabled(t *testing.T) {
+	a := rampSource(1000, 0, 0)
+	b := rampSource(500, 100_000, 0)
+
+	s := NewSwitchingAudioSource(0)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+
+	out := readUntilEOF(t, s, 128)
+	if len(out) != 1500 {
+		t.Fatalf("expected 1500 samples, got %d", len(out))
+	}
+	for i := 0; i < 1000; i++ {
+		if out[i] != float32(i) {
+			t.Fatalf("sample %d: expected %f, got %f", i, float32(i), out[i])
+		}
+	}
+	for i := 0; i < 500; i++ {
+		if out[1000+i] != float32(100_000+i) {
+			t.Fatalf("sample %d: expected %f, got %f", 1000+i, float32(100_000+i), out[1000+i])
+		}
+	}
+	expectDone(t, s)
+}
+
+func TestDisabledNegativeDurationSafe(t *testing.T) {
+	s := NewSwitchingAudioSource(-44100)
+	a := rampSource(64, 0, 0)
+	s.SetPrimary(a)
+	out := readUntilEOF(t, s, 16)
+	if len(out) != 64 {
+		t.Fatalf("expected 64 samples, got %d", len(out))
+	}
+}
+
+// TestCrossfadeMixExact verifies the fade region sample-by-sample against the
+// equal-power formula and checks total output length.
+func TestCrossfadeMixExact(t *testing.T) {
+	const fade = 400 // samples
+	const lenA, lenB = 2000, 1600
+	const va, vb = 0.25, 0.5
+
+	a := constSource(lenA, va, 0)
+	b := constSource(lenB, vb, 0)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+
+	out := readUntilEOF(t, s, 128)
+
+	wantLen := lenA + lenB - fade
+	if len(out) != wantLen {
+		t.Fatalf("expected %d samples, got %d", wantLen, len(out))
+	}
+
+	// Region 1: pure A.
+	for i := 0; i < lenA-fade; i++ {
+		if out[i] != va {
+			t.Fatalf("pre-fade sample %d: expected %f, got %f", i, float32(va), out[i])
+		}
+	}
+
+	// Region 2: the fade, equal-power mix computed per frame.
+	for i := 0; i < fade; i++ {
+		frameStart := i - i%Channels
+		x := float64(frameStart) / float64(fade)
+		gainOut := float32(math.Cos(x * math.Pi / 2))
+		gainIn := float32(math.Sin(x * math.Pi / 2))
+		want := va*gainOut + vb*gainIn
+
+		got := out[lenA-fade+i]
+		if diff := float64(got - want); math.Abs(diff) > 1e-6 {
+			t.Fatalf("fade sample %d: expected %f, got %f", i, want, got)
+		}
+	}
+
+	// Region 3: pure B.
+	for i := lenA; i < wantLen; i++ {
+		if out[i] != vb {
+			t.Fatalf("post-fade sample %d: expected %f, got %f", i, float32(vb), out[i])
+		}
+	}
+
+	expectDone(t, s)
+}
+
+// TestCrossfadeClampsPeaks checks that two loud correlated signals, whose
+// equal-power sum would exceed full scale mid-fade, are clamped below the
+// int16 overflow threshold.
+func TestCrossfadeClampsPeaks(t *testing.T) {
+	const fade = 200
+	a := constSource(1000, 0.9, 0)
+	b := constSource(1000, 0.9, 0)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+
+	out := readUntilEOF(t, s, 64)
+	var clamped bool
+	for i, v := range out {
+		if v > maxSampleValue || v < -1 {
+			t.Fatalf("sample %d out of range: %f", i, v)
+		}
+		if v == maxSampleValue {
+			clamped = true
+		}
+	}
+	if !clamped {
+		t.Fatal("expected the clamp to engage mid-fade (0.9*(cos+sin) peaks above 1)")
+	}
+}
+
+// TestNoSecondaryBitExact verifies that with crossfade enabled but no next
+// track, the lookahead path is byte-for-byte transparent and EOF timing
+// matches the original behavior.
+func TestNoSecondaryBitExact(t *testing.T) {
+	const n = 5000
+	a := rampSource(n, 0, 0)
+
+	s := NewSwitchingAudioSource(600)
+	s.SetPrimary(a)
+
+	var out []float32
+	buf := make([]float32, 128)
+	for {
+		nn, err := s.Read(buf)
+		out = append(out, buf[:nn]...)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) < n {
+			expectNotDone(t, s)
+		}
+	}
+
+	if len(out) != n {
+		t.Fatalf("expected %d samples, got %d", n, len(out))
+	}
+	for i := range out {
+		if out[i] != float32(i) {
+			t.Fatalf("sample %d: expected %f, got %f", i, float32(i), out[i])
+		}
+	}
+	expectDone(t, s)
+}
+
+// TestLateSecondaryDuringDrain attaches the next track while the tail of the
+// previous one is already draining; the remaining tail should crossfade.
+func TestLateSecondaryDuringDrain(t *testing.T) {
+	const fade = 400
+	const lenA = 1000
+	a := constSource(lenA, 0.5, 0)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+
+	// Drain some of the track. After these reads the decoder has hit EOF and
+	// part of the tail is gone.
+	buf := make([]float32, 200)
+	var consumed int
+	for consumed < 800 {
+		n, err := s.Read(buf)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		consumed += n
+	}
+
+	// Now the next track shows up late.
+	b := constSource(1000, 0.25, 0)
+	s.SetSecondary(b)
+
+	out := readUntilEOF(t, s, 200)
+	total := consumed + len(out)
+
+	// The remaining tail (lenA - consumed) overlaps with B.
+	wantTotal := lenA + 1000 - (lenA - consumed)
+	if total != wantTotal {
+		t.Fatalf("expected %d total samples, got %d", wantTotal, total)
+	}
+
+	// The middle of the shortened fade must contain contributions of both
+	// tracks (equal-power correctly starts at pure A, so sample 0 is not
+	// mixed).
+	// Equal-power mixing can exceed either input mid-fade; assert the sample
+	// is simply not equal to either pure value.
+	mid := (lenA - consumed) / 2
+	if v := out[mid]; math.Abs(float64(v-0.5)) < 0.01 || math.Abs(float64(v-0.25)) < 0.01 {
+		t.Fatalf("expected mid-fade sample to be a mix of both tracks, got %f", v)
+	}
+}
+
+// TestSecondaryShorterThanFade makes the incoming track end before the fade
+// completes; the tail must finish against silence without stalling and the
+// second track's end must be reported.
+func TestSecondaryShorterThanFade(t *testing.T) {
+	const fade = 800
+	a := constSource(2000, 0.5, 0)
+	b := constSource(300, 0.25, 0) // much shorter than the fade
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+
+	out := readUntilEOF(t, s, 128)
+
+	// All of A (with its tail faded) plus all of B mixed in.
+	if len(out) != 2000 {
+		t.Fatalf("expected 2000 samples, got %d", len(out))
+	}
+	expectDone(t, s)
+}
+
+// TestSkipMidFadeResets replaces the playing source mid-fade (a manual skip);
+// the fade must be aborted and the new source play cleanly from its start.
+func TestSkipMidFadeResets(t *testing.T) {
+	const fade = 400
+	a := constSource(1000, 0.5, 0)
+	b := constSource(1000, 0.25, 0)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+
+	// Read until the crossfade into B is genuinely in progress.
+	readUntilFading(t, s, 100)
+
+	// User skips to a new track entirely.
+	c := rampSource(500, 100_000, 0)
+	s.SetPrimary(c)
+
+	out := readUntilEOF(t, s, 100)
+	if len(out) != 500 {
+		t.Fatalf("expected 500 samples of C, got %d", len(out))
+	}
+	for i := range out {
+		if out[i] != float32(100_000+i) {
+			t.Fatalf("sample %d: expected pure C value %f, got %f", i, float32(100_000+i), out[i])
+		}
+	}
+}
+
+// TestPromoteSameSourceKeepsFade re-sets the already-promoted source (what
+// the daemon does when acknowledging a track change) and verifies the fade
+// keeps going instead of restarting.
+func TestPromoteSameSourceKeepsFade(t *testing.T) {
+	const fade = 400
+	a := constSource(1000, 0.5, 0)
+	b := constSource(1000, 0.25, 0)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+
+	consumed := readUntilFading(t, s, 100)
+
+	// Daemon acknowledges the transition with the same source pointer.
+	s.SetPrimary(b)
+
+	s.cond.L.Lock()
+	fading := s.fading
+	s.cond.L.Unlock()
+	if !fading {
+		t.Fatal("re-promoting the same source must not abort the fade")
+	}
+
+	out := readUntilEOF(t, s, 100)
+	if consumed+len(out) != 1000+1000-fade {
+		t.Fatalf("expected %d total samples, got %d", 2000-fade, consumed+len(out))
+	}
+}
+
+// TestSeekResetsLookahead seeks during normal lookahead playback and checks
+// the output resumes from the seek target with no stale buffered audio.
+func TestSeekResetsLookahead(t *testing.T) {
+	// 2 seconds of ramp audio.
+	n := 2 * SampleRate * Channels
+	a := rampSource(n, 0, 0)
+
+	s := NewSwitchingAudioSource(800)
+	s.SetPrimary(a)
+
+	buf := make([]float32, 256)
+	if _, err := s.Read(buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Seek to 1000ms.
+	if err := s.SetPositionMs(1000); err != nil {
+		t.Fatalf("seek failed: %v", err)
+	}
+
+	nn, err := s.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantFirst := float32(1000 * SampleRate / 1000 * Channels)
+	if nn == 0 || buf[0] != wantFirst {
+		t.Fatalf("expected first sample after seek to be %f, got %f", wantFirst, buf[0])
+	}
+}
+
+// TestPositionCompensatesLookahead verifies PositionMs reports where the
+// listener is, not where the decoder is.
+func TestPositionCompensatesLookahead(t *testing.T) {
+	n := 2 * SampleRate * Channels
+	a := rampSource(n, 0, 0)
+
+	const fade = 44100 // half a second of lookahead
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+
+	// Consume exactly 250ms of audio.
+	consumeTarget := SampleRate / 4 * Channels
+	buf := make([]float32, 1024)
+	var consumed int
+	for consumed < consumeTarget {
+		nn, err := s.Read(buf[:min(1024, consumeTarget-consumed)])
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		consumed += nn
+	}
+
+	got := s.PositionMs()
+	if got < 245 || got > 255 {
+		t.Fatalf("expected reported position ~250ms, got %dms", got)
+	}
+
+	// Sanity check: the decoder itself is far ahead.
+	if raw := a.PositionMs(); raw < 700 {
+		t.Fatalf("expected decoder position to be ahead (>=700ms), got %dms", raw)
+	}
+}
+
+// TestPartialAndOddReads exercises small, odd-sized output buffers and
+// chunk-limited sources.
+func TestPartialAndOddReads(t *testing.T) {
+	const fade = 100
+	a := constSource(1000, 0.5, 6) // source dribbles 6 samples at a time
+	b := constSource(400, 0.25, 10)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+
+	out := readUntilEOF(t, s, 7) // odd-sized destination buffer
+	if len(out) != 1000+400-fade {
+		t.Fatalf("expected %d samples, got %d", 1000+400-fade, len(out))
+	}
+}
+
+// TestEOFWithFinalChunk covers sources that return io.EOF together with the
+// last samples instead of on a separate call.
+func TestEOFWithFinalChunk(t *testing.T) {
+	const fade = 200
+	a := constSource(900, 0.5, 0)
+	a.eofWithLastRead = true
+	b := constSource(600, 0.25, 0)
+	b.eofWithLastRead = true
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+
+	out := readUntilEOF(t, s, 128)
+	if len(out) != 900+600-fade {
+		t.Fatalf("expected %d samples, got %d", 900+600-fade, len(out))
+	}
+}
+
+// TestDoneFiresOncePerTrack verifies done fires exactly once per finished
+// track across a crossfaded transition.
+func TestDoneFiresOncePerTrack(t *testing.T) {
+	const fade = 200
+	a := constSource(800, 0.5, 0)
+	b := constSource(800, 0.25, 0)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+
+	// Consume until the fade begins (A's EOF discovered).
+	readUntilFading(t, s, 100)
+	expectDone(t, s) // A's end reported at fade start
+
+	// Daemon acknowledges the promotion, which arms done for track B.
+	s.SetPrimary(b)
+
+	expectNotDone(t, s)
+	readUntilEOF(t, s, 100)
+	expectDone(t, s) // B's end reported at its EOF
+}
+
+// TestServesWithoutFullBuffer verifies playback flows as soon as the fade
+// reserve is intact, without demanding a completely full lookahead (a slow
+// source must not stall the output while audio is available).
+func TestServesWithoutFullBuffer(t *testing.T) {
+	const fade = 400
+	// Source dribbles 50 samples per read; total is far below the ring
+	// capacity of fade+lookaheadHeadroom.
+	a := rampSource(2000, 0, 50)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+
+	// The very first read must return audio once the reserve is covered,
+	// even though the ring is nowhere near full.
+	buf := make([]float32, 64)
+	n, err := s.Read(buf)
+	if err != nil || n == 0 {
+		t.Fatalf("expected immediate audio with partial buffer, got n=%d err=%v", n, err)
+	}
+	if buf[0] != 0 {
+		t.Fatalf("expected first sample 0, got %f", buf[0])
+	}
+
+	// And the reserve must genuinely be intact at this point.
+	s.cond.L.Lock()
+	if s.bufLen < fade {
+		t.Fatalf("fade reserve violated: bufLen=%d < %d", s.bufLen, fade)
+	}
+	s.cond.L.Unlock()
+}
+
+// TestNoStallWithGreedySource models real decoders, which fill whatever
+// buffer they are handed: the first read after start must not block until the
+// entire reserve is decoded.
+func TestNoStallWithGreedySource(t *testing.T) {
+	const fade = 44100 * 4        // large reserve
+	a := rampSource(fade*3, 0, 0) // greedy: no maxRead cap
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+
+	buf := make([]float32, 256)
+	n, err := s.Read(buf)
+	if err != nil || n == 0 {
+		t.Fatalf("expected audio, got n=%d err=%v", n, err)
+	}
+
+	// A greedy decoder given the whole ring would have decoded
+	// fade+lookaheadHeadroom samples; bounded fills must stay far below that.
+	a.mu.Lock()
+	decoded := a.pos
+	a.mu.Unlock()
+	if decoded >= fade {
+		t.Fatalf("first read decoded %d samples, fill is not bounded", decoded)
+	}
+}
+
+// TestSkipToPrefetchedNoAlias covers skipping straight to the track that was
+// prefetched: promoting it must clear the secondary alias, otherwise EOF
+// would fade the stream into its own exhausted self.
+func TestSkipToPrefetchedNoAlias(t *testing.T) {
+	const fade = 200
+	a := constSource(800, 0.5, 0)
+	b := rampSource(600, 0, 0)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+
+	// User skips straight to the prefetched track.
+	s.SetPrimary(b)
+
+	out := readUntilEOF(t, s, 128)
+	if len(out) != 600 {
+		t.Fatalf("expected exactly B's 600 samples, got %d", len(out))
+	}
+	for i := range out {
+		if out[i] != float32(i) {
+			t.Fatalf("sample %d: expected %f got %f (aliased replay?)", i, float32(i), out[i])
+		}
+	}
+}
+
+// TestClearSecondary verifies a nil secondary detaches a previously prefetched
+// stream (used when the daemon's next-track plan changes).
+func TestClearSecondary(t *testing.T) {
+	const fade = 200
+	a := constSource(800, 0.5, 0)
+	b := constSource(600, 0.25, 0)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+	s.SetSecondary(b)
+	s.SetSecondary(nil)
+
+	out := readUntilEOF(t, s, 128)
+	if len(out) != 800 {
+		t.Fatalf("expected only A's 800 samples, got %d", len(out))
+	}
+	for _, v := range out {
+		if v != 0.5 {
+			t.Fatal("secondary audio leaked after being cleared")
+		}
+	}
+}
+
+// TestErrorDeliveredAfterBufferedAudio: a non-EOF source error must not
+// discard audio that was already decoded into the lookahead.
+func TestErrorDeliveredAfterBufferedAudio(t *testing.T) {
+	const fade = 200
+	wantErr := errors.New("network exploded")
+	a := rampSource(2000, 0, 0)
+	a.failAt = 1000
+	a.failErr = wantErr
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+
+	var out []float32
+	buf := make([]float32, 128)
+	var got error
+	for {
+		n, err := s.Read(buf)
+		out = append(out, buf[:n]...)
+		if err != nil {
+			got = err
+			break
+		}
+	}
+
+	if len(out) != 1000 {
+		t.Fatalf("expected all 1000 decoded samples before the error, got %d", len(out))
+	}
+	if !errors.Is(got, wantErr) {
+		t.Fatalf("expected injected error, got %v", got)
+	}
+}
+
+// TestDisabledSeekKeepsEOFSemantics: with crossfade disabled, a seek must NOT
+// re-arm the done signal (original behavior only re-armed it in SetPrimary).
+func TestDisabledSeekKeepsEOFSemantics(t *testing.T) {
+	a := rampSource(400, 0, 0)
+
+	s := NewSwitchingAudioSource(0)
+	s.SetPrimary(a)
+	readUntilEOF(t, s, 128)
+	expectDone(t, s)
+
+	// Seek back into the still-loaded source and drain it again.
+	if err := s.SetPositionMs(0); err != nil {
+		t.Fatalf("seek failed: %v", err)
+	}
+	readUntilEOF(t, s, 128)
+	expectNotDone(t, s)
+}
+
+// TestConcurrentAccess smokes thread-safety with the race detector.
+func TestConcurrentAccess(t *testing.T) {
+	const fade = 400
+	a := constSource(50_000, 0.5, 0)
+	b := constSource(50_000, 0.25, 0)
+
+	s := NewSwitchingAudioSource(fade)
+	s.SetPrimary(a)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		buf := make([]float32, 512)
+		for {
+			_, err := s.Read(buf)
+			if err == io.EOF {
+				return
+			} else if err != nil {
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		time.Sleep(time.Millisecond)
+		s.SetSecondary(b)
+		time.Sleep(time.Millisecond)
+		_ = s.PositionMs()
+		_ = s.SetPositionMs(10)
+	}()
+
+	wg.Wait()
+}

--- a/player/stream.go
+++ b/player/stream.go
@@ -10,12 +10,25 @@ import (
 type Stream struct {
 	PlaybackId []byte
 
+	// RequestedId is the id this stream was created for, before any relinking
+	// to an alternative track. Callers keep referring to the stream by the id
+	// they requested, which may differ from the media's own id.
+	RequestedId librespot.SpotifyId
+
 	Source librespot.AudioSource
 	Media  *librespot.Media
 	File   *metadatapb.AudioFile
 }
 
 func (s *Stream) Is(id librespot.SpotifyId) bool {
+	// A restricted track may have been relinked to an alternative with a
+	// different gid (see getUnrestrictedTrack); without this check a
+	// prefetched stream for such a track is never recognized and gets loaded
+	// again from scratch, discarding the already-playing prefetched audio.
+	if id.Type() == s.RequestedId.Type() && bytes.Equal(id.Id(), s.RequestedId.Id()) {
+		return true
+	}
+
 	if id.Type() == librespot.SpotifyIdTypeTrack && s.Media.IsTrack() {
 		return bytes.Equal(id.Id(), s.Media.Track().Gid)
 	} else if id.Type() == librespot.SpotifyIdTypeEpisode && s.Media.IsEpisode() {


### PR DESCRIPTION
Implements crossfade between tracks, closing the gap discussed in #170.

## How it works

All the work happens in `SwitchingAudioSource`, which already handles the gapless hand-off between the playing track and the prefetched next one, so crossfade support ends up being a natural extension of the existing design rather than a new subsystem.

When `crossfade_duration` is set, the source keeps a lookahead of the playing track in a ring buffer sized to the fade plus a small headroom, filled with bounded reads so a greedy decoder can never stall playback. Playback is served from the headroom above a full fade held in reserve, which means the end of a track is discovered by the decoder before the listener hears it: at that moment the buffered tail is faded out with equal-power gains (cos/sin) while the prefetched secondary fades in underneath it. No track duration metadata is involved, so seeks, podcasts and tracks with imprecise durations behave correctly by construction.

With `crossfade_duration: 0` (the default) the original read path runs untouched, byte for byte.

## Behavior details

- The track-done signal fires when the fade begins, so state, metadata, events and prefetch scheduling advance in sync with what the listener hears (same UX as the official clients). At the end of a context, with no next track, the tail drains first and EOF timing matches current behavior exactly.
- The daemon re-sets the promoted source when it acknowledges a track change; that same-pointer `SetPrimary` keeps the in-flight fade going, while a genuinely new source (manual skip) aborts the fade immediately. Promoting a source also clears a secondary alias of itself, so skipping straight to the prefetched track can no longer replay or fade into an exhausted stream.
- Reported positions are compensated for the lookahead, so the API and clients see the listener position, not the decoder position.
- Seeking drops the lookahead and any in-flight fade and restarts buffering at the target. Right after a start or seek, playback begins immediately from a partial buffer; a track that ends before the reserve fills simply gets a proportionally shorter fade.
- Edge cases covered: next track shorter than the fade (mixes against silence, both done signals still fire), prefetch attaching late while the tail is already draining (the remaining tail crossfades), partial reads, `io.EOF` returned together with the final chunk, non-EOF errors delivered only after already-decoded audio has played out, and frame alignment throughout so channels can never desynchronize.
- Mixed samples are clamped to 32767/32768 so the s16 output conversion cannot overflow when two loud tracks overlap.

## Related fixes in the series

Two pre-existing issues surfaced while testing transitions end to end; both matter for crossfade but stand on their own:

- `fix: recognize prefetched streams for relinked tracks`: when a restricted track is relinked to an alternative, `Stream.Is` never matched the id the stream was requested with, so the daemon discarded its own prefetched stream and loaded the same track again from scratch. Without crossfade this silently wasted the prefetch and produced a gap; with crossfade it replaced the already-fading stream mid-transition.
- `fix: keep the prefetched next track consistent with the playback plan`: repeat-track now prefetches the repeating track itself (so its ending is not truncated on every loop and the transition crossfades like any other), and repeat/shuffle toggles, queue changes and non-prefetched loads now drop a stale prefetched stream instead of leaving it attached for the player to switch or fade into.

## Configuration

```yaml
crossfade_duration: 5000 # milliseconds, 0 (default) disables
```

Documented in the README and `config_schema.json`.

## Testing

- `player/source_test.go` (21 tests, run with `-race`): bit-exact passthrough with crossfade disabled (including EOF/done semantics on seeks), sample-exact verification of the fade region against the equal-power formula, output length across transitions, peak clamping, no-secondary drain with original EOF timing, late prefetch attach, short next track, skip/seek/pause during an active fade, skip-to-prefetched aliasing, cleared secondary, greedy-decoder fill boundedness, error delivery after buffered audio, position compensation, partial/odd reads, EOF-with-final-chunk, done-per-track semantics, and a concurrency smoke test.
- Real-world validation on an always-on Spotify Connect device (pipe backend feeding an Icecast radio encoder on a 1 GB cloud box): recorded 20+ forced and natural transitions off the stream and analyzed them for silence gaps and sample discontinuities (none found through 1 s, 5 s, 7 s and 12 s fades); exercised rapid skip storms, seeks, pauses and volume changes during active fades via the API with no errors; verified repeat-track crossfades into its own restart without truncation; soaked under continuous playback with a clean journal.

Happy to adjust naming, defaults or split things differently if you'd prefer.

(Replaces #321, which could not be reopened after the branch was rebased.)
