### PR TITLE
fix: don't clip the start of a track on the pulseaudio backend

### DIFF
--- a/output/driver-pulseaudio.go
+++ b/output/driver-pulseaudio.go
@@ -161,11 +161,9 @@ func (out *pulseAudioOutput) Resume() error {
 
 func (out *pulseAudioOutput) Drop() error {
 	if out.stream.Running() {
-		// Drop all samples while running. This happens when seeking.
-		// So we stop playback, flush the buffer, and restart it again to clear
-		// what's in the buffer. Presumably, all new samples from this point on
-		// are the new samples (isn't there a race condition here with
-		// SwitchingAudioSource?).
+		// Stop and flush the buffer. We do not restart here: the caller
+		// resumes once the new source is set. Restarting raced with the
+		// source switch and clipped the start of the track (#292).
 		out.stream.Stop()
 		err := out.client.RawRequest(&proto.FlushPlaybackStream{
 			StreamIndex: out.stream.StreamIndex(),
@@ -173,10 +171,8 @@ func (out *pulseAudioOutput) Drop() error {
 		if err != nil {
 			return fmt.Errorf("Drop: could not flush playback: %e", err)
 		}
-		out.stream.Start()
 	} else {
-		// This sometimes happens. But we don't need to do anything: we already
-		// flushed the buffer in Pause().
+		// Already stopped, e.g. flushed in Pause().
 	}
 	return nil
 }

--- a/output/output.go
+++ b/output/output.go
@@ -13,7 +13,8 @@ type Output interface {
 	// Resume resumes the output.
 	Resume() error
 
-	// Drop empties the audio buffer without waiting.
+	// Drop empties the audio buffer without waiting. It must not resume or
+	// restart playback; the caller resumes explicitly when needed.
 	Drop() error
 
 	// DelayMs returns the output device delay in milliseconds.

--- a/player/player.go
+++ b/player/player.go
@@ -218,6 +218,9 @@ func (p *Player) manageLoop() {
 	// initial volume is 1
 	volume := float32(1)
 
+	// whether the output is paused, so seek knows whether to resume after Drop
+	paused := false
+
 	// init main source
 	source := NewSwitchingAudioSource(p.crossfadeSamples)
 
@@ -247,6 +250,13 @@ loop:
 					p.log.Debugf("created new output device")
 				}
 
+				// Flush the previous source before switching, otherwise the
+				// new track's opening is buffered then dropped, clipping it on
+				// pulseaudio (#292).
+				if data.drop {
+					_ = out.Drop()
+				}
+
 				// set source
 				source.SetPrimary(data.source)
 				if data.paused {
@@ -260,10 +270,7 @@ loop:
 						break
 					}
 				}
-
-				if data.drop {
-					_ = out.Drop()
-				}
+				paused = data.paused
 
 				p.startedPlaying = time.Now()
 				cmd.resp <- nil
@@ -278,10 +285,12 @@ loop:
 					if err := out.Resume(); err != nil {
 						cmd.resp <- err
 					} else {
+						paused = false
 						cmd.resp <- nil
 						p.ev <- Event{Type: EventTypeResume}
 					}
 				} else {
+					paused = false
 					cmd.resp <- nil
 				}
 			case playerCmdPause:
@@ -289,10 +298,12 @@ loop:
 					if err := out.Pause(); err != nil {
 						cmd.resp <- err
 					} else {
+						paused = true
 						cmd.resp <- nil
 						p.ev <- Event{Type: EventTypePause}
 					}
 				} else {
+					paused = true
 					cmd.resp <- nil
 				}
 			case playerCmdStop:
@@ -313,7 +324,11 @@ loop:
 					} else if err = out.Drop(); err != nil {
 						cmd.resp <- err
 					} else {
-						cmd.resp <- nil
+						// Drop no longer restarts the stream; resume unless paused.
+						if !paused {
+							err = out.Resume()
+						}
+						cmd.resp <- err
 					}
 				} else {
 					cmd.resp <- nil

--- a/player/player_test.go
+++ b/player/player_test.go
@@ -1,0 +1,181 @@
+package player
+
+import (
+	"slices"
+	"sync"
+	"testing"
+
+	librespot "github.com/devgianlu/go-librespot"
+	"github.com/devgianlu/go-librespot/output"
+)
+
+// recordingOutput is a fake output.Output that records call order. Drop also
+// snapshots which source was primary when it ran, so tests can prove Drop
+// executes before source.SetPrimary swaps in the new track.
+type recordingOutput struct {
+	mu    sync.Mutex
+	calls []string
+
+	// source is the SwitchingAudioSource manageLoop passed as the reader when
+	// creating this output; captured by the newOutput hook.
+	source *SwitchingAudioSource
+
+	// dropPrimary records, once per Drop() call, the primary source observed
+	// right before the flush.
+	dropPrimary []librespot.AudioSource
+}
+
+func (o *recordingOutput) record(name string) {
+	o.mu.Lock()
+	o.calls = append(o.calls, name)
+	o.mu.Unlock()
+}
+
+func (o *recordingOutput) Pause() error  { o.record("Pause"); return nil }
+func (o *recordingOutput) Resume() error { o.record("Resume"); return nil }
+
+func (o *recordingOutput) Drop() error {
+	var cur librespot.AudioSource
+	if o.source != nil {
+		o.source.cond.L.Lock()
+		cur = o.source.source[o.source.which]
+		o.source.cond.L.Unlock()
+	}
+
+	o.mu.Lock()
+	o.calls = append(o.calls, "Drop")
+	o.dropPrimary = append(o.dropPrimary, cur)
+	o.mu.Unlock()
+	return nil
+}
+
+func (o *recordingOutput) DelayMs() (int64, error) { return 0, nil }
+func (o *recordingOutput) SetVolume(float32)       {}
+func (o *recordingOutput) Error() <-chan error     { return make(chan error) }
+func (o *recordingOutput) Close() error            { o.record("Close"); return nil }
+
+// snapshot returns a copy of the recorded calls so far, safe to inspect
+// without racing the manage loop.
+func (o *recordingOutput) snapshot() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.calls...)
+}
+
+// newTestPlayer builds a Player driven by manageLoop with newOutput wired to
+// the given recordingOutput, bypassing NewPlayer (which requires a real
+// spclient/session) since manageLoop only touches p.log, p.cmd, p.ev,
+// p.crossfadeSamples and p.newOutput.
+func newTestPlayer(t *testing.T, out *recordingOutput) *Player {
+	t.Helper()
+
+	p := &Player{
+		log: &librespot.NullLogger{},
+		cmd: make(chan playerCmd),
+		ev:  make(chan Event, 128),
+		newOutput: func(reader librespot.Float32Reader, volume float32) (output.Output, error) {
+			out.source = reader.(*SwitchingAudioSource)
+			return out, nil
+		},
+	}
+
+	go p.manageLoop()
+	t.Cleanup(p.Close)
+
+	return p
+}
+
+func lastIndex(s []string, v string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestLoadDropFlushesBeforeSourceSwitch locks in the issue #292 fix: on a
+// track-load command with drop=true, the output must be flushed (Drop) while
+// the previous track is still primary, before source.SetPrimary swaps in the
+// new one. Flushing afterwards raced with the new source being read into the
+// buffer, clipping the first samples of the incoming track.
+func TestLoadDropFlushesBeforeSourceSwitch(t *testing.T) {
+	a := rampSource(100, 0, 0)
+	b := rampSource(100, 1000, 0)
+
+	out := &recordingOutput{}
+	p := newTestPlayer(t, out)
+
+	if err := p.SetPrimaryStream(a, false, false); err != nil {
+		t.Fatalf("initial load failed: %v", err)
+	}
+	if err := p.SetPrimaryStream(b, false, true); err != nil {
+		t.Fatalf("drop load failed: %v", err)
+	}
+
+	calls := out.snapshot()
+
+	out.mu.Lock()
+	dropPrimary := append([]librespot.AudioSource(nil), out.dropPrimary...)
+	out.mu.Unlock()
+
+	// Only the second load requested a drop, so exactly one Drop call should
+	// have been recorded.
+	if len(dropPrimary) != 1 {
+		t.Fatalf("expected exactly one Drop call, got %d (calls=%v)", len(dropPrimary), calls)
+	}
+	if dropPrimary[0] != librespot.AudioSource(a) {
+		t.Fatalf("expected Drop to observe 'a' still primary (i.e. run before the switch to 'b'), got %v", dropPrimary[0])
+	}
+
+	// Sanity: by the time the command returned, the switch had happened.
+	out.source.cond.L.Lock()
+	cur := out.source.source[out.source.which]
+	out.source.cond.L.Unlock()
+	if cur != librespot.AudioSource(b) {
+		t.Fatalf("expected primary source to be 'b' after the load completed, got %v", cur)
+	}
+}
+
+// TestSeekResumesOnlyWhilePlaying locks in the seek behavior change: Drop no
+// longer self-restarts the stream, so a seek while playing must explicitly
+// call Resume after Drop, but a seek while paused must not resume playback.
+func TestSeekResumesOnlyWhilePlaying(t *testing.T) {
+	a := rampSource(1000, 0, 0)
+
+	out := &recordingOutput{}
+	p := newTestPlayer(t, out)
+
+	if err := p.SetPrimaryStream(a, false, false); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	// Seek while playing: Resume must immediately follow Drop.
+	if err := p.SeekMs(500); err != nil {
+		t.Fatalf("seek while playing failed: %v", err)
+	}
+
+	calls := out.snapshot()
+	dropIdx, resumeIdx := lastIndex(calls, "Drop"), lastIndex(calls, "Resume")
+	if dropIdx == -1 || resumeIdx != dropIdx+1 {
+		t.Fatalf("expected Resume to immediately follow Drop while playing, got calls=%v", calls)
+	}
+
+	// Pause, then seek again: this time Resume must NOT be called.
+	if err := p.Pause(); err != nil {
+		t.Fatalf("pause failed: %v", err)
+	}
+	preSeekLen := len(out.snapshot())
+
+	if err := p.SeekMs(700); err != nil {
+		t.Fatalf("seek while paused failed: %v", err)
+	}
+
+	callsAfter := out.snapshot()[preSeekLen:]
+	if slices.Contains(callsAfter, "Resume") {
+		t.Fatalf("seek while paused must not resume playback, got calls=%v", callsAfter)
+	}
+	if !slices.Contains(callsAfter, "Drop") {
+		t.Fatalf("expected Drop during a paused seek, got calls=%v", callsAfter)
+	}
+}


### PR DESCRIPTION
Fixes #292.

On pulseaudio, cold (non-prefetched) track loads start ~1s in. `Drop()` is the only backend that self-restarts the stream (`Stop` + `FlushPlaybackStream` + `Start`), against its `Output` contract ("empties the buffer without waiting"). A load runs `SetPrimary` -> `Resume` -> `Drop`; since `Resume` no-ops on an already-running stream, the pull loop has already read the new track's opening into the buffer, which `Drop`'s flush then discards. Prefetched loads buffer ahead and survive it (hence next/prev stay clean).

Fix:
- `Drop()` stops and flushes without restarting (matching the alsa/toolbox/pipe backends and the interface contract).
- The load path flushes *before* switching sources.
- The seek path resumes explicitly, since `Drop` no longer restarts.

Adds a player test covering the drop-before-switch ordering and the seek resume/paused behavior. Verified on a Raspberry Pi 4 (pipewire-pulse).

Note: seeking in the brief window right after end-of-track auto-pause now resumes playback, since the player now tracks pause state to decide whether to resume after the flush.