### PR TITLE
fix: reset context metadata when loading a new context

### DIFF
--- a/daemon/controls.go
+++ b/daemon/controls.go
@@ -263,9 +263,11 @@ func (p *AppPlayer) loadContext(ctx context.Context, spotCtx *connectpb.Context,
 		}
 	}
 
-	if p.state.player.ContextMetadata == nil {
-		p.state.player.ContextMetadata = map[string]string{}
-	}
+	// Replace (don't merge): this is a fresh context, so metadata from the
+	// previous one must not linger — otherwise keys the new context omits (e.g.
+	// context_description, which drives Spotify's "Next from:" label) keep their
+	// stale values.
+	p.state.player.ContextMetadata = map[string]string{}
 	for k, v := range spotCtx.Metadata {
 		p.state.player.ContextMetadata[k] = v
 	}

--- a/daemon/controls.go
+++ b/daemon/controls.go
@@ -511,7 +511,15 @@ func (p *AppPlayer) setQueue(ctx context.Context, prev []*connectpb.ContextTrack
 
 	p.state.tracks.SetQueue(prev, next)
 	p.state.player.PrevTracks = p.state.tracks.PrevTracks()
-	p.state.player.NextTracks = p.state.tracks.NextTracks(ctx, next)
+	// Report upcoming tracks from our own list (queue + context iterator) rather
+	// than echoing the command's next_tracks hint. On a context switch the
+	// controller can send a set_queue whose next_tracks still lead with the
+	// previous context's leftovers; echoing them shows tracks under "Next from:"
+	// that will never play, since advanceNext follows this same list, not the
+	// hint. SetQueue above already captured the (is_queued) manual queue from the
+	// hint, so only the reorder-by-hint of context tracks is dropped — and that
+	// never affected playback anyway.
+	p.state.player.NextTracks = p.state.tracks.NextTracks(ctx, nil)
 	p.updateState(ctx)
 
 	// The upcoming track may have changed: a stream prefetched under the old

--- a/daemon/controls.go
+++ b/daemon/controls.go
@@ -264,11 +264,16 @@ func (p *AppPlayer) loadContext(ctx context.Context, spotCtx *connectpb.Context,
 	}
 
 	// Replace (don't merge): this is a fresh context, so metadata from the
-	// previous one must not linger — otherwise keys the new context omits (e.g.
-	// context_description, which drives Spotify's "Next from:" label) keep their
-	// stale values.
+	// previous one must not linger. Copy the play command's metadata, then
+	// overlay the resolved context's metadata (ctxTracks.Metadata()), which
+	// carries context_description — the label Spotify renders as "Next from: …"
+	// (linked to ContextUri) — that the command alone usually omits. Mirrors the
+	// transfer path in player.go.
 	p.state.player.ContextMetadata = map[string]string{}
 	for k, v := range spotCtx.Metadata {
+		p.state.player.ContextMetadata[k] = v
+	}
+	for k, v := range ctxTracks.Metadata() {
 		p.state.player.ContextMetadata[k] = v
 	}
 


### PR DESCRIPTION
### What

Reset `PlayerState.ContextMetadata` when loading a new context in `loadContext`, instead of merging the new context's metadata into the map left over from the previous one.

### Why

When switching from one context to another (e.g. starting an album while a different album is playing), every field of the new context — `SessionId`, `ContextUri`, `ContextUrl`, `Restrictions`, tracks — is replaced, but `ContextMetadata` was only merged. Keys the previous context set that the new one omits therefore survived. Most visibly, `context_description` lingered, so Spotify's queue kept showing "Next from: \<previous album\>" while the correct track played.

The transfer path in `daemon/player.go` already resets the map before copying; this brings `loadContext` in line. The same-URI `update_context` path still merges, which is correct there.

### Test plan

- `go build -v -o /dev/null ./cmd/daemon`
- `gofmt -l .` clean
- On-device: play album A, start a track from album B, confirm the queue header reads album B.

Closes #330
