### PR TITLE
feat: support starting playback at a position via POST /player/play

### DIFF
--- a/api-spec.yml
+++ b/api-spec.yml
@@ -44,6 +44,11 @@ components:
         paused:
           description: Start playback as paused
           type: boolean
+        position:
+          description: >-
+            Position in milliseconds to start playback at within the selected
+            track (0 starts from the beginning)
+          type: integer
 paths:
   /:
     get:

--- a/daemon/api_server.go
+++ b/daemon/api_server.go
@@ -143,6 +143,9 @@ type ApiRequestDataPlay struct {
 	Uri       string `json:"uri"`
 	SkipToUri string `json:"skip_to_uri"`
 	Paused    bool   `json:"paused"`
+	// Position is the position in milliseconds to start playback at within the
+	// selected track. Zero starts from the beginning.
+	Position int64 `json:"position"`
 }
 
 type ApiRequestDataNext struct {

--- a/daemon/player.go
+++ b/daemon/player.go
@@ -560,8 +560,23 @@ func (p *AppPlayer) handleApiRequest(ctx context.Context, req ApiRequest) (any, 
 			}
 		}
 
-		if err := p.loadContext(ctx, spotCtx, skipTo, data.Paused, true); err != nil {
+		// When starting at a position, load paused and seek before unpausing so
+		// no audio plays from 0:00 while the track loads. loadContext returns
+		// once the track is loaded, so no polling is needed to time the seek.
+		loadPaused := data.Paused || data.Position > 0
+		if err := p.loadContext(ctx, spotCtx, skipTo, loadPaused, true); err != nil {
 			return nil, fmt.Errorf("failed loading context: %w", err)
+		}
+
+		if data.Position > 0 {
+			if err := p.seek(ctx, data.Position); err != nil {
+				p.app.log.WithError(err).Warnf("failed seeking to initial position %dms", data.Position)
+			}
+			if !data.Paused {
+				if err := p.play(ctx); err != nil {
+					p.app.log.WithError(err).Warnf("failed resuming after initial seek")
+				}
+			}
 		}
 
 		return nil, nil


### PR DESCRIPTION
Up for another one? Essentially just exposing the ability to start a song at a specific position over the API.

Add an optional `position` (milliseconds) to the play request so a context can be started at a specific position within the selected track, completing the existing `skip_to_uri` (which track) with where in the track. This mirrors the position handling Spotify Connect transfers already use internally.

When a position is given the track is loaded paused and seeked before unpausing, so no audio plays from 0:00 while it loads — and since loadContext returns once the track is loaded, no client-side polling is needed to time the seek.

Purely additive: a new request field plus seek/resume orchestration in the existing play handler using the existing seek()/play() helpers.