### PR TITLE
feat: add /player/output to reopen audio output live

### DIFF
--- a/api-spec.yml
+++ b/api-spec.yml
@@ -156,6 +156,30 @@ paths:
       responses:
         200:
           description: Successful response
+  /player/output:
+    post:
+      description: >-
+        Reopen the audio output on a different device without touching the
+        Spotify session, preserving the current track, playback position,
+        paused state and volume. Useful for switching speakers (e.g. ALSA or
+        bluealsa) live without reconnecting. If playback is active it switches
+        devices immediately (with a brief audio gap); if nothing is playing the
+        device is recorded and takes effect on the next output open. An empty
+        device selects the configured default output device.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                device:
+                  description: >-
+                    The output device name to open (backend-specific, e.g. an
+                    ALSA device). Empty selects the configured default.
+                  type: string
+      responses:
+        200:
+          description: Successful response
   /player/playpause:
     post:
       description: Resume playback when paused, or pause playback when playing

--- a/daemon/api_server.go
+++ b/daemon/api_server.go
@@ -75,6 +75,7 @@ const (
 	ApiRequestTypeAddToQueue          ApiRequestType = "add_to_queue"
 	ApiRequestTypeToken               ApiRequestType = "token"
 	ApiRequestSetDeviceName           ApiRequestType = "set_device_name"
+	ApiRequestTypeReopenOutput        ApiRequestType = "reopen_output"
 )
 
 type ApiEventType string
@@ -669,6 +670,22 @@ func (s *ConcreteApiServer) serve() {
 		}
 
 		s.handleRequest(ApiRequest{Type: ApiRequestSetDeviceName, Data: data.Name}, w)
+	})
+	m.HandleFunc("/player/output", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		var data struct {
+			Device string `json:"device"`
+		}
+		if err := jsonDecode(r, &data); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		s.handleRequest(ApiRequest{Type: ApiRequestTypeReopenOutput, Data: data.Device}, w)
 	})
 	m.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
 		opts := &websocket.AcceptOptions{}

--- a/daemon/player.go
+++ b/daemon/player.go
@@ -610,6 +610,11 @@ func (p *AppPlayer) handleApiRequest(ctx context.Context, req ApiRequest) (any, 
 	case ApiRequestSetDeviceName:
 		p.setDeviceName(ctx, req.Data.(string))
 		return nil, nil
+	case ApiRequestTypeReopenOutput:
+		if err := p.player.ReopenOutput(req.Data.(string)); err != nil {
+			return nil, fmt.Errorf("failed reopening output: %w", err)
+		}
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unknown request type: %s", req.Type)
 	}

--- a/output/driver-alsa.go
+++ b/output/driver-alsa.go
@@ -111,6 +111,18 @@ func (out *alsaOutput) isFormatSupported(hwparams *C.snd_pcm_hw_params_t, format
 }
 
 func (out *alsaOutput) setupPcm() error {
+	// Drop alsa-lib's in-process configuration cache before opening, so the
+	// device name re-resolves against the configuration files as they are NOW.
+	// A long-running daemon otherwise keeps resolving aliases against the tree
+	// cached at first use: alsa-lib's change detection compares file identity,
+	// timestamps and size, which misses in-place rewrites that keep the size
+	// (e.g. swapping one bluealsa device MAC for another — same string length)
+	// — observed in the field as every (re)open reaching the departed
+	// speaker's MAC with "PCM not found" until the process was restarted.
+	// Opens are rare (output creation and live reopens), so the re-parse cost
+	// is irrelevant.
+	C.snd_config_update_free_global()
+
 	cdevice := C.CString(out.device)
 	defer C.free(unsafe.Pointer(cdevice))
 	if err := C.snd_pcm_open(&out.pcmHandle, cdevice, C.SND_PCM_STREAM_PLAYBACK, 0); err < 0 {

--- a/player/player.go
+++ b/player/player.go
@@ -56,7 +56,12 @@ type Player struct {
 
 	cdnQuarantine map[string]time.Time
 
-	newOutput func(source librespot.Float32Reader, volume float32) (output.Output, error)
+	newOutput func(source librespot.Float32Reader, volume float32, device string) (output.Output, error)
+
+	// defaultAudioDevice is the output device to open initially. manageLoop
+	// tracks the current device from here and it can be changed at runtime via
+	// ReopenOutput.
+	defaultAudioDevice string
 
 	cmd chan playerCmd
 	ev  chan Event
@@ -76,6 +81,7 @@ const (
 	playerCmdSeek
 	playerCmdPosition
 	playerCmdVolume
+	playerCmdReopenOutput
 	playerCmdClose
 )
 
@@ -188,14 +194,15 @@ func NewPlayer(opts *Options) (*Player, error) {
 		normalisationUseAlbumGain: opts.NormalisationUseAlbumGain,
 		normalisationPregain:      opts.NormalisationPregain,
 		countryCode:               opts.CountryCode,
-		newOutput: func(reader librespot.Float32Reader, volume float32) (output.Output, error) {
+		defaultAudioDevice:        opts.AudioDevice,
+		newOutput: func(reader librespot.Float32Reader, volume float32, device string) (output.Output, error) {
 			return output.NewOutput(&output.NewOutputOptions{
 				Log:              opts.Log,
 				Backend:          opts.AudioBackend,
 				Reader:           reader,
 				SampleRate:       SampleRate,
 				ChannelCount:     Channels,
-				Device:           opts.AudioDevice,
+				Device:           device,
 				RuntimeSocket:    opts.AudioBackendRuntimeSocket,
 				Mixer:            opts.MixerDevice,
 				Control:          opts.MixerControlName,
@@ -229,6 +236,9 @@ func (p *Player) manageLoop() {
 	// whether the output is paused, so seek knows whether to resume after Drop
 	paused := false
 
+	// current output device; can be changed at runtime via playerCmdReopenOutput
+	device := p.defaultAudioDevice
+
 	// init main source
 	source := NewSwitchingAudioSource(p.crossfadeSamples)
 
@@ -248,7 +258,7 @@ loop:
 				// create a new output device if needed
 				if out == nil {
 					var err error
-					out, err = p.newOutput(source, volume)
+					out, err = p.newOutput(source, volume, device)
 					if err != nil {
 						cmd.resp <- err
 						break
@@ -359,6 +369,56 @@ loop:
 				if out != nil {
 					out.SetVolume(volume)
 				}
+			case playerCmdReopenOutput:
+				// Reopen the output on a new device without touching the Spotify
+				// session, keeping the current source and playback position.
+				device = cmd.data.(string)
+
+				if out == nil {
+					// Nothing playing: the new device takes effect the next time
+					// an output is opened. Callers wanting audio to resume (e.g.
+					// recovery after the device died) should issue a play/resume
+					// afterwards.
+					cmd.resp <- nil
+					break
+				}
+
+				// Close the old device before opening the new one: some backends
+				// (e.g. pulseaudio) start reading from the source as soon as the
+				// output is constructed, so two live outputs would corrupt the
+				// stream. A sub-second gap from the discarded buffer is expected.
+				_ = out.Drop()
+				_ = out.Close()
+				out = nil
+				outErr = make(<-chan error)
+
+				newOut, err := p.newOutput(source, volume, device)
+				if err != nil {
+					// The old device is already gone; playback stays silent until
+					// an output is reopened. Surface the failure to the caller.
+					p.log.WithError(err).Warnf("failed reopening output on %q", device)
+					cmd.resp <- err
+					break
+				}
+
+				out = newOut
+				outErr = out.Error()
+
+				if paused {
+					err = out.Pause()
+				} else {
+					err = out.Resume()
+				}
+				if err != nil {
+					_ = out.Close()
+					out = nil
+					outErr = make(<-chan error)
+					cmd.resp <- err
+					break
+				}
+
+				p.log.Infof("reopened output device on %q", device)
+				cmd.resp <- nil
 			case playerCmdClose:
 				break loop
 			default:
@@ -455,6 +515,22 @@ func (p *Player) PositionMs() int64 {
 	p.cmd <- playerCmd{typ: playerCmdPosition, resp: resp}
 	pos := <-resp
 	return pos.(int64)
+}
+
+// ReopenOutput reopens the audio output on the given device without touching
+// the Spotify session, preserving the current playback position, paused state
+// and volume. If playback is currently active it switches devices live (with a
+// brief audio gap); if nothing is playing it just records the device for the
+// next output open. It returns an error if the new device fails to open, in
+// which case playback is left stopped.
+func (p *Player) ReopenOutput(device string) error {
+	resp := make(chan any, 1)
+	p.cmd <- playerCmd{typ: playerCmdReopenOutput, data: device, resp: resp}
+	if err := <-resp; err != nil {
+		return err.(error)
+	}
+
+	return nil
 }
 
 func (p *Player) SetPrimaryStream(source librespot.AudioSource, paused, drop bool) error {

--- a/player/player_test.go
+++ b/player/player_test.go
@@ -23,6 +23,10 @@ type recordingOutput struct {
 	// dropPrimary records, once per Drop() call, the primary source observed
 	// right before the flush.
 	dropPrimary []librespot.AudioSource
+
+	// devices records, in order, the device names manageLoop opened the output
+	// on (captured by the newOutput hook).
+	devices []string
 }
 
 func (o *recordingOutput) record(name string) {
@@ -73,8 +77,11 @@ func newTestPlayer(t *testing.T, out *recordingOutput) *Player {
 		log: &librespot.NullLogger{},
 		cmd: make(chan playerCmd),
 		ev:  make(chan Event, 128),
-		newOutput: func(reader librespot.Float32Reader, volume float32) (output.Output, error) {
+		newOutput: func(reader librespot.Float32Reader, volume float32, device string) (output.Output, error) {
 			out.source = reader.(*SwitchingAudioSource)
+			out.mu.Lock()
+			out.devices = append(out.devices, device)
+			out.mu.Unlock()
 			return out, nil
 		},
 	}
@@ -177,5 +184,111 @@ func TestSeekResumesOnlyWhilePlaying(t *testing.T) {
 	}
 	if !slices.Contains(callsAfter, "Drop") {
 		t.Fatalf("expected Drop during a paused seek, got calls=%v", callsAfter)
+	}
+}
+
+// TestReopenOutputSwitchesDeviceLive locks in the output-recovery behavior:
+// ReopenOutput while playing must flush and close the old output, open a new
+// one on the requested device, and resume playback — all without touching the
+// Spotify source (the same primary stream stays selected).
+func TestReopenOutputSwitchesDeviceLive(t *testing.T) {
+	a := rampSource(1000, 0, 0)
+
+	out := &recordingOutput{}
+	p := newTestPlayer(t, out)
+
+	if err := p.SetPrimaryStream(a, false, false); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	preLen := len(out.snapshot())
+
+	if err := p.ReopenOutput("hifi"); err != nil {
+		t.Fatalf("reopen failed: %v", err)
+	}
+
+	calls := out.snapshot()[preLen:]
+	dropIdx := slices.Index(calls, "Drop")
+	closeIdx := slices.Index(calls, "Close")
+	resumeIdx := slices.Index(calls, "Resume")
+	if dropIdx == -1 || closeIdx == -1 || resumeIdx == -1 {
+		t.Fatalf("expected Drop, Close and Resume during a live reopen, got calls=%v", calls)
+	}
+	if !(dropIdx < closeIdx && closeIdx < resumeIdx) {
+		t.Fatalf("expected Drop -> Close -> Resume order during reopen, got calls=%v", calls)
+	}
+
+	// The output must have been reopened on the requested device.
+	out.mu.Lock()
+	devices := append([]string(nil), out.devices...)
+	out.mu.Unlock()
+	if len(devices) < 2 || devices[len(devices)-1] != "hifi" {
+		t.Fatalf("expected the output to be reopened on device \"hifi\", got devices=%v", devices)
+	}
+
+	// The primary source must be unchanged: reopening the output does not touch
+	// the Spotify session.
+	out.source.cond.L.Lock()
+	cur := out.source.source[out.source.which]
+	out.source.cond.L.Unlock()
+	if cur != librespot.AudioSource(a) {
+		t.Fatalf("expected the primary source to be unchanged after reopen, got %v", cur)
+	}
+}
+
+// TestReopenOutputPausedStaysPaused ensures a reopen while paused reopens the
+// device but does NOT resume playback.
+func TestReopenOutputPausedStaysPaused(t *testing.T) {
+	a := rampSource(1000, 0, 0)
+
+	out := &recordingOutput{}
+	p := newTestPlayer(t, out)
+
+	if err := p.SetPrimaryStream(a, true, false); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	preLen := len(out.snapshot())
+
+	if err := p.ReopenOutput("hifi"); err != nil {
+		t.Fatalf("reopen failed: %v", err)
+	}
+
+	calls := out.snapshot()[preLen:]
+	if slices.Contains(calls, "Resume") {
+		t.Fatalf("reopen while paused must not resume playback, got calls=%v", calls)
+	}
+	if !slices.Contains(calls, "Close") {
+		t.Fatalf("expected the old output to be closed during reopen, got calls=%v", calls)
+	}
+	if !slices.Contains(calls, "Pause") {
+		t.Fatalf("expected the reopened output to be paused, got calls=%v", calls)
+	}
+}
+
+// TestReopenOutputNothingPlaying ensures a reopen with no output open is a
+// no-op that just records the device for the next output open.
+func TestReopenOutputNothingPlaying(t *testing.T) {
+	out := &recordingOutput{}
+	p := newTestPlayer(t, out)
+
+	if err := p.ReopenOutput("hifi"); err != nil {
+		t.Fatalf("reopen with nothing playing failed: %v", err)
+	}
+
+	if calls := out.snapshot(); len(calls) != 0 {
+		t.Fatalf("expected no output calls when reopening with nothing playing, got calls=%v", calls)
+	}
+
+	// The device only takes effect on the next output open: loading a stream now
+	// must open on the recorded device.
+	a := rampSource(100, 0, 0)
+	if err := p.SetPrimaryStream(a, false, false); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	out.mu.Lock()
+	devices := append([]string(nil), out.devices...)
+	out.mu.Unlock()
+	if len(devices) != 1 || devices[0] != "hifi" {
+		t.Fatalf("expected the next output to open on device \"hifi\", got devices=%v", devices)
 	}
 }


### PR DESCRIPTION
Proposal to allow restoring audio stream without restarting go-librespot. Supports both restoring after your audio connection has failed - or just live-switching between audio outputs without having to restart go-librespot.

Add an endpoint and player command to reopen the audio output on a different device without touching the Spotify session, preserving the current track, playback position, paused state and volume.

The player now tracks the current output device (initialised from the configured AudioDevice) and exposes ReopenOutput, backed by a new playerCmdReopenOutput handled in the manage loop. Reopening flushes and closes the old output before opening the new one — some backends (e.g. pulseaudio) start reading the source as soon as the output is constructed, so two live outputs would corrupt the stream — then restores the paused/playing state. When nothing is playing the device is just recorded for the next output open.

POST /player/output {"device": "..."} drives this from the API; an empty device selects the configured default.