### PR TITLE
fix: clamp samples before integer conversion in the pipe output

### DIFF
--- a/output/driver-pipe.go
+++ b/output/driver-pipe.go
@@ -32,6 +32,51 @@ type pipeOutput struct {
 	transform func([]float32, []byte) int
 }
 
+// Largest float that scales into an int16 without wrapping.
+const maxSampleValueS16 = float32(0x7fff) / float32(0x8000)
+
+func clampSample(f, max float32) float32 {
+	if f < -1 {
+		return -1
+	}
+	if f > max {
+		return max
+	}
+	return f
+}
+
+func newPipeTransform(format string) (func([]float32, []byte) int, error) {
+	switch format {
+	case "s16le":
+		return func(in []float32, out []byte) int {
+			for i := 0; i < len(in); i++ {
+				sample := int16(clampSample(in[i], maxSampleValueS16) * 32768)
+				binary.LittleEndian.PutUint16(out[i*2:], uint16(sample))
+			}
+			return len(in) * 2
+		}, nil
+	case "s32le":
+		// float32 rounds 2147483647 up to 2^31, so scale in float64.
+		return func(in []float32, out []byte) int {
+			for i := 0; i < len(in); i++ {
+				sample := int32(float64(clampSample(in[i], 1)) * 2147483647)
+				binary.LittleEndian.PutUint32(out[i*4:], uint32(sample))
+			}
+			return len(in) * 4
+		}, nil
+	case "f32le":
+		return func(in []float32, out []byte) int {
+			for i := 0; i < len(in); i++ {
+				sample := math.Float32bits(in[i])
+				binary.LittleEndian.PutUint32(out[i*4:], sample)
+			}
+			return len(in) * 4
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown output pipe format: %s", format)
+	}
+}
+
 func newPipeOutput(opts *NewOutputOptions) (out *pipeOutput, err error) {
 	out = &pipeOutput{
 		reader:         opts.Reader,
@@ -43,33 +88,9 @@ func newPipeOutput(opts *NewOutputOptions) (out *pipeOutput, err error) {
 
 	out.cond = sync.NewCond(&out.lock)
 
-	switch opts.OutputPipeFormat {
-	case "s16le":
-		out.transform = func(in []float32, out []byte) int {
-			for i := 0; i < len(in); i++ {
-				sample := int16(in[i] * 32768)
-				binary.LittleEndian.PutUint16(out[i*2:], uint16(sample))
-			}
-			return len(in) * 2
-		}
-	case "s32le":
-		out.transform = func(in []float32, out []byte) int {
-			for i := 0; i < len(in); i++ {
-				sample := int32(in[i] * 2147483648)
-				binary.LittleEndian.PutUint32(out[i*4:], uint32(sample))
-			}
-			return len(in) * 4
-		}
-	case "f32le":
-		out.transform = func(in []float32, out []byte) int {
-			for i := 0; i < len(in); i++ {
-				sample := math.Float32bits(in[i])
-				binary.LittleEndian.PutUint32(out[i*4:], sample)
-			}
-			return len(in) * 4
-		}
-	default:
-		return nil, fmt.Errorf("unknown output pipe format: %s", opts.OutputPipeFormat)
+	out.transform, err = newPipeTransform(opts.OutputPipeFormat)
+	if err != nil {
+		return nil, err
 	}
 
 	// Open the FIFO for writing as non-blocking to cause an error if there is no reader.

--- a/output/driver-pipe_test.go
+++ b/output/driver-pipe_test.go
@@ -1,0 +1,141 @@
+package output
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+func s16(t *testing.T, in []float32) []int16 {
+	t.Helper()
+
+	transform, err := newPipeTransform("s16le")
+	if err != nil {
+		t.Fatalf("newPipeTransform: %v", err)
+	}
+
+	buf := make([]byte, len(in)*2)
+	if n := transform(in, buf); n != len(in)*2 {
+		t.Fatalf("transform wrote %d bytes, want %d", n, len(in)*2)
+	}
+
+	out := make([]int16, len(in))
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(buf[i*2:]))
+	}
+	return out
+}
+
+func s32(t *testing.T, in []float32) []int32 {
+	t.Helper()
+
+	transform, err := newPipeTransform("s32le")
+	if err != nil {
+		t.Fatalf("newPipeTransform: %v", err)
+	}
+
+	buf := make([]byte, len(in)*4)
+	if n := transform(in, buf); n != len(in)*4 {
+		t.Fatalf("transform wrote %d bytes, want %d", n, len(in)*4)
+	}
+
+	out := make([]int32, len(in))
+	for i := range out {
+		out[i] = int32(binary.LittleEndian.Uint32(buf[i*4:]))
+	}
+	return out
+}
+
+func TestPipeTransformS16LEBounds(t *testing.T) {
+	cases := []struct {
+		in   float32
+		want int16
+	}{
+		{0, 0},
+		{0.5, 16384},
+		{-0.5, -16384},
+		{maxSampleValueS16, 32767},
+		{1, 32767},
+		{1.0001, 32767},
+		{1.02, 32767},
+		{2, 32767},
+		{100, 32767},
+		{float32(math.Inf(1)), 32767},
+		{-1, -32768},
+		{-1.02, -32768},
+		{-2, -32768},
+		{float32(math.Inf(-1)), -32768},
+	}
+
+	for _, c := range cases {
+		if got := s16(t, []float32{c.in})[0]; got != c.want {
+			t.Errorf("s16le(%v) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPipeTransformS32LEBounds(t *testing.T) {
+	cases := []struct {
+		in   float32
+		want int32
+	}{
+		{0, 0},
+		{0.5, 1073741823},
+		{1, 2147483647},
+		{1.02, 2147483647},
+		{100, 2147483647},
+		{-1, -2147483647},
+		{-1.02, -2147483647},
+		{-100, -2147483647},
+	}
+
+	for _, c := range cases {
+		if got := s32(t, []float32{c.in})[0]; got != c.want {
+			t.Errorf("s32le(%v) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// A wrap shows up as a non-monotonic step.
+func TestPipeTransformMonotonic(t *testing.T) {
+	const steps = 4001
+
+	in := make([]float32, steps)
+	for i := range in {
+		in[i] = -2 + 4*float32(i)/float32(steps-1)
+	}
+
+	out := s16(t, in)
+	for i := 1; i < len(out); i++ {
+		if out[i] < out[i-1] {
+			t.Fatalf("non-monotonic at %v -> %v: %d -> %d (wrapped)",
+				in[i-1], in[i], out[i-1], out[i])
+		}
+	}
+
+	if out[0] != -32768 || out[len(out)-1] != 32767 {
+		t.Errorf("sweep endpoints = %d..%d, want -32768..32767", out[0], out[len(out)-1])
+	}
+}
+
+func TestPipeTransformInRangeUnchanged(t *testing.T) {
+	const steps = 2001
+
+	in := make([]float32, steps)
+	for i := range in {
+		in[i] = -1 + 2*maxSampleValueS16*float32(i)/float32(steps-1)
+	}
+
+	out := s16(t, in)
+	for i, v := range in {
+		if want := int16(v * 32768); out[i] != want {
+			t.Errorf("s16le(%v) = %d, want %d (unclamped path changed)", v, out[i], want)
+		}
+	}
+}
+
+func TestPipeTransformUnknownFormat(t *testing.T) {
+	if _, err := newPipeTransform("s24le"); err == nil {
+		t.Fatal("expected an error for an unsupported format")
+	}
+}


### PR DESCRIPTION
Chasing occasional clicks on loud tracks I ended up here: the pipe transforms convert float32 straight to int16/int32 with no clamping, and decoder output isn't guaranteed to stay inside [-1, 1]. With s16le the *32768 scale means exactly 1.0 already overflows and wraps:

```
 1.0    -> -32768
 1.02   -> -32113
-1.0001 ->  32765
```

s32le is the same thing (2147483648 is one past int32 max), though there it's implementation-defined. It wraps on amd64, saturates on arm64. The alsa driver already clamps, so this just brings the pipe in line. Kept the *32768 scale and clamped to 32767/32768 so in-range samples stay bit-identical; s32 has to scale in float64 since float32 can't represent 2147483647. Pulled the switch into a small unexported constructor so the transforms are testable without a fifo.
