### PR TITLE
fix: dispatch zeroconf addUser from the current user

### DIFF
--- a/zeroconf/zeroconf.go
+++ b/zeroconf/zeroconf.go
@@ -212,8 +212,7 @@ func (z *Zeroconf) handleAddUser(writer http.ResponseWriter, request *http.Reque
 
 	z.userLock.Lock()
 
-	// check if we are authenticating the same user that is holding the session
-	if z.currentUser == username || z.authenticatingUser == username {
+	if z.authenticatingUser == username {
 		z.userLock.Unlock()
 
 		writer.WriteHeader(http.StatusOK)

--- a/zeroconf/zeroconf_test.go
+++ b/zeroconf/zeroconf_test.go
@@ -1,0 +1,155 @@
+package zeroconf
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	librespot "github.com/devgianlu/go-librespot"
+	"github.com/devgianlu/go-librespot/dh"
+)
+
+func newTestZeroconf(t *testing.T) *Zeroconf {
+	z := &Zeroconf{
+		log:      &librespot.NullLogger{},
+		reqsChan: make(chan NewUserRequest),
+	}
+
+	var err error
+	z.dh, err = dh.NewDiffieHellman()
+	if err != nil {
+		t.Fatalf("failed initializing diffiehellman: %v", err)
+	}
+
+	return z
+}
+
+func newAddUserRequest(t *testing.T, z *Zeroconf, username, deviceName string) *http.Request {
+	clientDh, err := dh.NewDiffieHellman()
+	if err != nil {
+		t.Fatalf("failed initializing client diffiehellman: %v", err)
+	}
+
+	sharedSecret := clientDh.Exchange(z.dh.PublicKeyBytes())
+	baseKey := func() []byte { sum := sha1.Sum(sharedSecret); return sum[:16] }()
+
+	mac := hmac.New(sha1.New, baseKey)
+	mac.Write([]byte("checksum"))
+	checksumKey := mac.Sum(nil)
+
+	mac.Reset()
+	mac.Write([]byte("encryption"))
+	encryptionKey := func() []byte { sum := mac.Sum(nil); return sum[:16] }()
+
+	iv := make([]byte, 16)
+	if _, err := rand.Read(iv); err != nil {
+		t.Fatalf("failed reading random iv: %v", err)
+	}
+
+	bc, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		t.Fatalf("failed initializing aes cipher: %v", err)
+	}
+
+	payload := []byte("auth-blob-payload")
+	encrypted := make([]byte, len(payload))
+	cipher.NewCTR(bc, iv).XORKeyStream(encrypted, payload)
+
+	mac = hmac.New(sha1.New, checksumKey)
+	mac.Write(encrypted)
+	checksum := mac.Sum(nil)
+
+	blob := append(append(append([]byte{}, iv...), encrypted...), checksum...)
+
+	req := httptest.NewRequest(http.MethodPost, "/?action=addUser", nil)
+	req.Form = url.Values{
+		"userName":   {username},
+		"blob":       {base64.StdEncoding.EncodeToString(blob)},
+		"clientKey":  {base64.StdEncoding.EncodeToString(clientDh.PublicKeyBytes())},
+		"deviceName": {deviceName},
+	}
+	return req
+}
+
+func TestHandleAddUserSameUserReauthenticates(t *testing.T) {
+	z := newTestZeroconf(t)
+	z.currentUser = "alice"
+
+	dispatched := make(chan NewUserRequest, 1)
+	go func() {
+		req := <-z.reqsChan
+		dispatched <- req
+		req.result <- true
+	}()
+
+	rec := httptest.NewRecorder()
+	if err := z.handleAddUser(rec, newAddUserRequest(t, z, "alice", "phone")); err != nil {
+		t.Fatalf("handleAddUser failed: %v", err)
+	}
+
+	select {
+	case req := <-dispatched:
+		if req.Username != "alice" {
+			t.Fatalf("dispatched request for wrong username: %s", req.Username)
+		}
+	default:
+		t.Fatal("add user request for the current user was not dispatched")
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", rec.Code)
+	}
+
+	var resp AddUserResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed decoding response: %v", err)
+	}
+	if resp.Status != 101 {
+		t.Fatalf("unexpected response status: %d", resp.Status)
+	}
+
+	if z.currentUser != "alice" {
+		t.Fatalf("unexpected current user: %s", z.currentUser)
+	}
+}
+
+func TestHandleAddUserAuthenticatingSameUserShortCircuits(t *testing.T) {
+	z := newTestZeroconf(t)
+	z.authenticatingUser = "alice"
+
+	rec := httptest.NewRecorder()
+	done := make(chan error, 1)
+	go func() { done <- z.handleAddUser(rec, newAddUserRequest(t, z, "alice", "phone")) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("handleAddUser failed: %v", err)
+		}
+	case req := <-z.reqsChan:
+		t.Fatalf("unexpected dispatch for user %s", req.Username)
+	case <-time.After(time.Second):
+		t.Fatal("handleAddUser did not return")
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", rec.Code)
+	}
+
+	var resp AddUserResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed decoding response: %v", err)
+	}
+	if resp.Status != 101 {
+		t.Fatalf("unexpected response status: %d", resp.Status)
+	}
+}


### PR DESCRIPTION
A device that loses its connect state registration cannot recover on its own. The app falls back to the local addUser path, handleAddUser answers OK without dispatching, and nothing happens. The device never registers again and the app sits on "Connecting..." forever until the daemon is restarted.

What makes it unrecoverable is the currentUser arm. When the request comes from the user already holding the session it returns OK without creating a session and without logging anything, so the one recovery signal the app does send is swallowed.

This drops that arm so a same user addUser rebuilds the session and registers the device again. The authenticatingUser arm stays, so retries sent while one is already in flight are still absorbed. librespot-java and librespot have no guard on the user already holding the session and rebuild on every addUser.

How I hit it: a daemon up 20 hours. A capture during a tap shows getInfo returning 200 with activeUser set, then addUser answered `{"status":101,"statusString":"OK"}` repeatedly, while the log stayed empty and "accepted zeroconf" never appeared once in the whole run. Both sockets stayed up and the dealer kept its ping pong going, so the process was healthy. A restart fixed it instantly.

There was a dealer reconnect earlier in the day but I believe it recovered, since a successful re registration is silent at info level and a failed put would have warned. My reading is that the registration was dropped later on the server side with nothing visible to the client, similar to librespot-org/librespot#247. Either way addUser is the signal the app uses to recover and it should not be swallowed. I had no API credential to confirm the device was gone from the cloud device list, so that part is inferred.
