### PR TITLE
feat: identify unsupported URIs early

### DIFF
--- a/ids.go
+++ b/ids.go
@@ -12,12 +12,55 @@ import (
 
 var UriRegexp = regexp.MustCompile("^spotify:([a-z]+):([0-9a-zA-Z]{21,22})$")
 
-func InferSpotifyIdTypeFromContextUri(uri string) SpotifyIdType {
-	if strings.HasPrefix(uri, "spotify:episode:") || strings.HasPrefix(uri, "spotify:show:") {
-		return SpotifyIdTypeEpisode
+// ContextUriType extracts the type segment of a context URI, that is the "album"
+// of "spotify:album:xxx". User scoped URIs such as
+// "spotify:user:someone:playlist:xxx" carry the username in that position, so
+// for those the segment after it is the meaningful one.
+func ContextUriType(uri string) string {
+	parts := strings.Split(uri, ":")
+	if len(parts) < 3 || parts[0] != "spotify" {
+		return ""
 	}
 
-	return SpotifyIdTypeTrack
+	if parts[1] == "user" && len(parts) >= 5 {
+		return parts[3]
+	}
+
+	return parts[1]
+}
+
+// InferSpotifyIdTypeFromContextUri returns the type of the *items* a context
+// holds. A ContextTrack often carries only a gid, and a gid does not say what it
+// identifies, so the context is what decides how to turn it back into a URI.
+//
+// Anything unrecognised returns SpotifyIdTypeUnknown instead of being assumed to
+// be a track.
+func InferSpotifyIdTypeFromContextUri(uri string) SpotifyIdType {
+	switch ContextUriType(uri) {
+	// Contexts made of podcast episodes or audiobook chapters.
+	case "episode", "show", "chapter", "audiobook":
+		return SpotifyIdTypeEpisode
+
+	// Contexts made of tracks. "collection" is Liked Songs; its saved episodes
+	// variant is spotify:collection:your-episodes, handled below.
+	case "album", "artist", "playlist", "track", "station", "dailymix",
+		"collection", "top", "trackset", "list", "local", "concept",
+		"running", "genre", "radio", "folder":
+		if uri == "spotify:collection:your-episodes" {
+			return SpotifyIdTypeEpisode
+		}
+		return SpotifyIdTypeTrack
+
+	case "ad", "app", "audio", "audiofile", "author", "clip", "conceptclass",
+		"concert", "image", "instance", "internal", "interruption", "licensor",
+		"localfileimage", "media", "meta", "mosaic", "partner", "prerelease",
+		"promotion", "room", "search", "socialsession", "suggest", "transition",
+		"user", "userimage", "zerotap":
+		return SpotifyIdTypeUnknown
+
+	default:
+		return SpotifyIdTypeUnknown
+	}
 }
 
 func ContextTrackToProvidedTrack(typ SpotifyIdType, track *connectpb.ContextTrack) *connectpb.ProvidedTrack {
@@ -56,6 +99,7 @@ const (
 	SpotifyIdTypeTrack    SpotifyIdType = "track"
 	SpotifyIdTypeEpisode  SpotifyIdType = "episode"
 	SpotifyIdTypePlaylist SpotifyIdType = "playlist"
+	SpotifyIdTypeUnknown  SpotifyIdType = ""
 )
 
 type SpotifyId struct {

--- a/ids_test.go
+++ b/ids_test.go
@@ -1,0 +1,83 @@
+package go_librespot
+
+import "testing"
+
+func TestContextUriType(t *testing.T) {
+	tests := []struct {
+		uri  string
+		want string
+	}{
+		{"spotify:album:5r36AJ6VOJtp00oxSkBZ5h", "album"},
+		{"spotify:playlist:37i9dQZF1E36KLdUfLiuUo", "playlist"},
+		{"spotify:collection:tracks", "collection"},
+		// User scoped URIs carry the username where the type usually sits.
+		{"spotify:user:someone:playlist:37i9dQZF1E36KLdUfLiuUo", "playlist"},
+		{"spotify:user:someone:collection", "user"},
+		{"", ""},
+		{"not-a-uri", ""},
+		{"spotify:album", ""},
+		{"http://open.spotify.com/album/xxx", ""},
+	}
+
+	for _, tt := range tests {
+		if got := ContextUriType(tt.uri); got != tt.want {
+			t.Errorf("ContextUriType(%q) = %q, want %q", tt.uri, got, tt.want)
+		}
+	}
+}
+
+// The contexts that already worked must keep working: getting any of these
+// wrong silently breaks normal playback.
+func TestInferSpotifyIdTypeTrackContexts(t *testing.T) {
+	uris := []string{
+		"spotify:album:5r36AJ6VOJtp00oxSkBZ5h",
+		"spotify:artist:53XhwfbYqKCa1cC15pYq2q",
+		"spotify:playlist:37i9dQZF1E36KLdUfLiuUo",
+		"spotify:track:2FY7b99s15jUprqC0M5NCT",
+		"spotify:station:playlist:37i9dQZF1E36KLdUfLiuUo",
+		"spotify:dailymix:xxx",
+		"spotify:collection:tracks",
+		"spotify:user:someone:playlist:37i9dQZF1E36KLdUfLiuUo",
+	}
+
+	for _, uri := range uris {
+		if got := InferSpotifyIdTypeFromContextUri(uri); got != SpotifyIdTypeTrack {
+			t.Errorf("InferSpotifyIdTypeFromContextUri(%q) = %q, want %q", uri, got, SpotifyIdTypeTrack)
+		}
+	}
+}
+
+func TestInferSpotifyIdTypeEpisodeContexts(t *testing.T) {
+	uris := []string{
+		"spotify:show:5CnDmMUG0S5bSSw612fs8C",
+		"spotify:episode:0Jv8TUEkzMplSPfX3ynBXu",
+		"spotify:collection:your-episodes",
+	}
+
+	for _, uri := range uris {
+		if got := InferSpotifyIdTypeFromContextUri(uri); got != SpotifyIdTypeEpisode {
+			t.Errorf("InferSpotifyIdTypeFromContextUri(%q) = %q, want %q", uri, got, SpotifyIdTypeEpisode)
+		}
+	}
+}
+
+// These used to be reported as tracks, which meant their ids were base62
+// decoded as track gids and failed confusingly later on.
+func TestInferSpotifyIdTypeUnsupportedContexts(t *testing.T) {
+	uris := []string{
+		"spotify:socialsession:5xwj7pphGg7mJSfWz2vXY8",
+		"spotify:prerelease:6nQjPI2xUOZjJ7bJPMFxtF",
+		"spotify:ad:xxx",
+		"spotify:image:xxx",
+		"spotify:user:someone",
+		"spotify:somethingnew:xxx",
+		"",
+		"garbage",
+	}
+
+	for _, uri := range uris {
+		if got := InferSpotifyIdTypeFromContextUri(uri); got != SpotifyIdTypeUnknown {
+			t.Errorf("InferSpotifyIdTypeFromContextUri(%q) = %q, want unknown", uri, got)
+		}
+	}
+}

--- a/spclient/context_resolver.go
+++ b/spclient/context_resolver.go
@@ -50,6 +50,9 @@ func isTracksComplete(ctx *connectpb.Context) bool {
 
 func NewContextResolver(ctx context.Context, log librespot.Logger, sp *Spclient, spotCtx *connectpb.Context) (_ *ContextResolver, err error) {
 	typ := librespot.InferSpotifyIdTypeFromContextUri(spotCtx.Uri)
+	if typ == librespot.SpotifyIdTypeUnknown {
+		return nil, fmt.Errorf("unsupported context type: %s", spotCtx.Uri)
+	}
 
 	if len(spotCtx.Pages) == 0 || !isTracksComplete(spotCtx) {
 		newSpotCtx, err := sp.ContextResolve(ctx, spotCtx.Uri)

--- a/spclient/spclient.go
+++ b/spclient/spclient.go
@@ -423,6 +423,10 @@ func (c *Spclient) PlaylistSignals(ctx context.Context, playlist librespot.Spoti
 }
 
 func (c *Spclient) ContextResolve(ctx context.Context, uri string) (*connectpb.Context, error) {
+	if librespot.InferSpotifyIdTypeFromContextUri(uri) == librespot.SpotifyIdTypeUnknown {
+		return nil, fmt.Errorf("unsupported context type: %s", uri)
+	}
+
 	resp, err := c.Request(ctx, "GET", fmt.Sprintf("/context-resolve/v1/%s", uri), nil, nil, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fail loud in occasions like #207 and #338