### PR TITLE
feat: debounce rapid next/prev into a single deferred track load

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ audio_output_pipe_format: s16le # Audio output pipe format (s16le, s32le, f32le)
 audio_output_pipe_wait_for_reader: false # Whether to wait for a reader to connect to the FIFO before starting playback (see below)
 bitrate: 160 # Playback bitrate (96, 160, 320)
 crossfade_duration: 0 # Crossfade duration between tracks in milliseconds (0 to disable)
+skip_debounce_ms: 600 # Coalesce rapid next/prev presses; the selected track loads once presses stop (0 to disable)
 volume_steps: 100 # Volume steps count
 initial_volume: 100 # Initial volume in steps (not applied to the mixer device)
 ignore_last_volume: false # Whether to ignore the last saved volume and always use initial_volume

--- a/cmd/daemon/cli_config.go
+++ b/cmd/daemon/cli_config.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/devgianlu/go-librespot/daemon"
 	"github.com/gofrs/flock"
@@ -55,6 +56,7 @@ type cliConfig struct {
 	NormalisationUseAlbumGain     bool     `koanf:"normalisation_use_album_gain"`
 	NormalisationPregain          float32  `koanf:"normalisation_pregain"`
 	CrossfadeDuration             int      `koanf:"crossfade_duration"`
+	SkipDebounceMs                int      `koanf:"skip_debounce_ms"`
 	ExternalVolume                bool     `koanf:"external_volume"`
 	ZeroconfEnabled               bool     `koanf:"zeroconf_enabled"`
 	ZeroconfPort                  int      `koanf:"zeroconf_port"`
@@ -123,6 +125,7 @@ func (c *cliConfig) toDaemonConfig() *daemon.Config {
 		NormalisationUseAlbumGain: c.NormalisationUseAlbumGain,
 		NormalisationPregain:      c.NormalisationPregain,
 		CrossfadeDuration:         c.CrossfadeDuration,
+		SkipDebounce:              time.Duration(c.SkipDebounceMs) * time.Millisecond,
 		ExternalVolume:            c.ExternalVolume,
 		DisableAutoplay:           c.DisableAutoplay,
 
@@ -204,6 +207,8 @@ func loadCLIConfig(cfg *cliConfig) error {
 
 		"volume_steps":   100,
 		"initial_volume": 100,
+
+		"skip_debounce_ms": 600,
 
 		"credentials.type": "zeroconf",
 

--- a/cmd/daemon/cli_config_test.go
+++ b/cmd/daemon/cli_config_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -18,6 +19,15 @@ func TestDefaultAudioBackend(t *testing.T) {
 		return
 	}
 	require.Equal(t, "alsa", got)
+}
+
+func TestSkipDebounceMapping(t *testing.T) {
+	var c cliConfig
+	c.SkipDebounceMs = 400
+	require.Equal(t, 400*time.Millisecond, c.toDaemonConfig().SkipDebounce)
+
+	c.SkipDebounceMs = 0
+	require.Zero(t, c.toDaemonConfig().SkipDebounce)
 }
 
 func TestParseSize(t *testing.T) {

--- a/config_schema.json
+++ b/config_schema.json
@@ -321,6 +321,12 @@
           "default": 0,
           "minimum": 0
         },
+        "skip_debounce_ms": {
+          "type": "integer",
+          "description": "How long to wait after a burst of next/prev commands before loading the selected track, in milliseconds, so rapid skipping costs one audio-key request instead of one per press. The first skip of a burst always loads immediately, so this only affects how long the daemon waits to see whether another skip follows. 0 disables debouncing",
+          "default": 600,
+          "minimum": 0
+        },
         "external_volume": {
           "type": "boolean",
           "description": "Whether volume is controlled externally, if true the app will not pre-multiply samples",

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -1,5 +1,7 @@
 package daemon
 
+import "time"
+
 // Config carries the runtime configuration for a daemon instance.
 type Config struct {
 	DeviceId    string
@@ -28,6 +30,12 @@ type Config struct {
 	CrossfadeDuration         int
 	ExternalVolume            bool
 	DisableAutoplay           bool
+
+	// SkipDebounce is how long a skip that follows another within this window
+	// waits before loading the track it landed on, so that a burst of next or
+	// prev presses costs one load rather than one per press. Zero loads every
+	// skip immediately.
+	SkipDebounce time.Duration
 
 	ZeroconfEnabled               bool
 	ZeroconfPort                  int

--- a/daemon/controls.go
+++ b/daemon/controls.go
@@ -287,7 +287,7 @@ func (p *AppPlayer) handlePlayerEvent(ev *player.Event) {
 			return
 		}
 
-		p.advanceNext(false, false, func(hasNextTrack bool, err error) {
+		p.advanceNext(false, false, 0, func(hasNextTrack bool, err error) {
 			if err != nil {
 				p.app.log.WithError(err).Error("failed advancing to next track")
 			}
@@ -527,14 +527,14 @@ func isUnplayableMedia(err error) bool {
 func (p *AppPlayer) loadCurrentTrackOrSkip(paused, drop, resume bool, then func(error)) {
 	uri := p.state.player.Track.GetUri()
 
-	p.loadCurrentTrack(paused, drop, resume, func(err error) {
+	p.loadCurrentTrack(paused, drop, resume, 0, func(err error) {
 		if err == nil || !isUnplayableMedia(err) {
 			then(err)
 			return
 		}
 
 		p.app.log.WithError(err).Warnf("current track unplayable, skipping forward: %s", uri)
-		p.advanceNext(true, drop, func(_ bool, err error) {
+		p.advanceNext(true, drop, 0, func(_ bool, err error) {
 			if err != nil {
 				then(fmt.Errorf("failed advancing past unplayable track: %w", err))
 				return
@@ -547,7 +547,12 @@ func (p *AppPlayer) loadCurrentTrackOrSkip(paused, drop, resume bool, then func(
 // loadCurrentTrack starts playing whatever the state points at. Only the
 // bookkeeping happens here: fetching the media runs on the loader lane, and then
 // is called back on the player loop once it has, with whatever went wrong.
-func (p *AppPlayer) loadCurrentTrack(paused, drop, resume bool, then func(error)) {
+//
+// The fetch is held back by delay, during which a newer load drops it unstarted.
+// Once started it cannot be recalled: the audio key request goes out before the
+// fetch can be cancelled, and a burst of those is what gets the daemon rate
+// limited.
+func (p *AppPlayer) loadCurrentTrack(paused, drop, resume bool, delay time.Duration, then func(error)) {
 	if p.primaryStream != nil {
 		unloadPosition := p.player.PositionMs()
 		p.sess.Events().OnPrimaryStreamUnload(p.primaryStream, unloadPosition)
@@ -583,6 +588,9 @@ func (p *AppPlayer) loadCurrentTrack(paused, drop, resume bool, then func(error)
 	p.state.player.PlaybackSpeed = 0 // not progressing while buffering
 	p.updateState()
 
+	// Announced per load rather than per fetch: a burst of skips moves the
+	// pointer on every press, and every stop it settles on is reported even
+	// though only the last one is fetched.
 	p.app.server.Emit(&ApiEvent{
 		Type: ApiEventTypeWillPlay,
 		Data: ApiEventDataWillPlay{
@@ -625,10 +633,17 @@ func (p *AppPlayer) loadCurrentTrack(paused, drop, resume bool, then func(error)
 	metadata := maps.Clone(p.state.player.Track.GetMetadata())
 	p.loadInFlight = true
 
+	var notBefore time.Time
+	if delay > 0 {
+		notBefore = time.Now().Add(delay)
+		p.app.log.WithField("uri", spotId.Uri()).Debugf("holding load for %s in case another skip follows", delay)
+	}
+
 	p.loader.submit(loaderJob{
-		name:  "load " + spotId.Uri(),
-		class: classLoad,
-		gen:   p.loadGen,
+		name:      "load " + spotId.Uri(),
+		class:     classLoad,
+		gen:       p.loadGen,
+		notBefore: notBefore,
 		run: func(ctx context.Context) loaderResult {
 			position, startsAtZero := trackPosition, fromStart
 			if resume {
@@ -1031,8 +1046,31 @@ func (p *AppPlayer) seek(position int64) error {
 	return nil
 }
 
+// skipDelay decides how long the load a skip ends in may wait: nothing for a
+// press on its own, the debounce window for one that follows another within
+// it. The first press of a burst loads at once, so a lone skip behaves as it
+// always has; each later one is held back long enough for the next press to
+// drop it.
+func skipDelay(debounce time.Duration, now, lastSkip time.Time) time.Duration {
+	if debounce > 0 && now.Sub(lastSkip) < debounce {
+		return debounce
+	}
+	return 0
+}
+
+// noteSkip records a next or prev press and reports how long the load it ends
+// in may wait.
+func (p *AppPlayer) noteSkip() time.Duration {
+	now := time.Now()
+	delay := skipDelay(p.app.cfg.SkipDebounce, now, p.lastSkipAt)
+	p.lastSkipAt = now
+	return delay
+}
+
 func (p *AppPlayer) skipPrev(allowSeeking bool) error {
-	if allowSeeking && p.player.PositionMs() > 3000 {
+	// The position read here belongs to the stream on its way out while a load
+	// is outstanding: a second press means the track before it, not a restart.
+	if allowSeeking && !p.loadInFlight && p.player.PositionMs() > 3000 {
 		return p.seek(0)
 	}
 
@@ -1043,9 +1081,10 @@ func (p *AppPlayer) skipPrev(allowSeeking bool) error {
 	}
 
 	p.app.log.Debug("skip previous track")
+	delay := p.noteSkip()
 	p.loadGen++
 
-	p.listJob("skip previous", classLoad, nil,
+	p.listJob("skip previous", classNav, nil,
 		func(_ context.Context, list *tracks.List) error {
 			list.GoPrev()
 			return nil
@@ -1060,7 +1099,7 @@ func (p *AppPlayer) skipPrev(allowSeeking bool) error {
 			p.state.player.Timestamp = time.Now().UnixMilli()
 			p.state.player.PositionAsOfTimestamp = 0
 
-			p.loadCurrentTrack(p.state.player.IsPaused, true, true, func(err error) {
+			p.loadCurrentTrack(p.state.player.IsPaused, true, true, delay, func(err error) {
 				if err != nil {
 					p.app.log.WithError(err).Warn("failed loading current track (skip prev)")
 				}
@@ -1073,8 +1112,10 @@ func (p *AppPlayer) skipPrev(allowSeeking bool) error {
 func (p *AppPlayer) skipNext(track *connectpb.ContextTrack) error {
 	p.sess.Events().OnPlayerSkipForward(p.primaryStream, p.player.PositionMs(), track != nil)
 
+	delay := p.noteSkip()
+
 	if track == nil {
-		p.advanceNext(true, true, func(hasNextTrack bool, err error) {
+		p.advanceNext(true, true, delay, func(hasNextTrack bool, err error) {
 			if err != nil {
 				p.app.log.WithError(err).Warn("failed skipping to next track")
 			}
@@ -1120,7 +1161,7 @@ func (p *AppPlayer) skipNext(track *connectpb.ContextTrack) error {
 			p.state.player.Timestamp = time.Now().UnixMilli()
 			p.state.player.PositionAsOfTimestamp = 0
 
-			p.loadCurrentTrack(p.state.player.IsPaused, true, true, func(err error) {
+			p.loadCurrentTrack(p.state.player.IsPaused, true, true, delay, func(err error) {
 				if err != nil {
 					p.app.log.WithError(err).Warn("failed loading current track (skip next)")
 				}
@@ -1137,9 +1178,10 @@ const maxConsecutiveUnplayableSkips = 50
 // advanceNext moves to the next track and starts it, reporting through then
 // whether there was one. A run of unplayable tracks is walked forward, bounded
 // by maxConsecutiveUnplayableSkips so a fully gated context cannot loop forever.
-func (p *AppPlayer) advanceNext(forceNext, drop bool, then func(hasNextTrack bool, err error)) {
+// delay holds back the load it ends in, see loadCurrentTrack.
+func (p *AppPlayer) advanceNext(forceNext, drop bool, delay time.Duration, then func(hasNextTrack bool, err error)) {
 	if p.state.tracks == nil {
-		p.advanceTo(false, nil, drop, then)
+		p.advanceTo(false, nil, drop, delay, then)
 		return
 	}
 
@@ -1147,7 +1189,7 @@ func (p *AppPlayer) advanceNext(forceNext, drop bool, then func(hasNextTrack boo
 	// navigate, and so no walk of the context either.
 	if !forceNext && p.state.player.Options.RepeatingTrack {
 		p.state.player.IsPaused = false
-		p.advanceTo(true, nil, drop, then)
+		p.advanceTo(true, nil, drop, delay, then)
 		return
 	}
 
@@ -1156,7 +1198,7 @@ func (p *AppPlayer) advanceNext(forceNext, drop bool, then func(hasNextTrack boo
 
 	var hasNextTrack bool
 	var seed []string
-	p.listJob("advance", classLoad, nil,
+	p.listJob("advance", classNav, nil,
 		func(ctx context.Context, list *tracks.List) error {
 			hasNextTrack = list.GoNext(ctx)
 
@@ -1185,13 +1227,13 @@ func (p *AppPlayer) advanceNext(forceNext, drop bool, then func(hasNextTrack boo
 
 			p.state.player.IsPaused = !hasNextTrack
 			p.publishSnapshot(snap)
-			p.advanceTo(hasNextTrack, seed, drop, then)
+			p.advanceTo(hasNextTrack, seed, drop, delay, then)
 		})
 }
 
 // advanceTo starts whatever advanceNext settled on, or hands over to autoplay
 // when the context has run out.
-func (p *AppPlayer) advanceTo(hasNextTrack bool, seed []string, drop bool, then func(hasNextTrack bool, err error)) {
+func (p *AppPlayer) advanceTo(hasNextTrack bool, seed []string, drop bool, delay time.Duration, then func(hasNextTrack bool, err error)) {
 	uri := p.state.player.Track.GetUri()
 
 	p.state.player.Timestamp = time.Now().UnixMilli()
@@ -1213,7 +1255,7 @@ func (p *AppPlayer) advanceTo(hasNextTrack bool, seed []string, drop bool, then 
 	// playlist playback — even though they play on official clients, which establish a licensed
 	// context. We cannot decrypt a refused track, so skip it instead of freezing the player.
 	// Remove once proper key licensing (PlayPlay) is implemented — tracked separately.
-	p.loadCurrentTrack(!hasNextTrack, drop, true, func(err error) {
+	p.loadCurrentTrack(!hasNextTrack, drop, true, delay, func(err error) {
 		if err == nil {
 			p.consecutiveUnplayableSkips = 0
 			then(hasNextTrack, nil)
@@ -1244,7 +1286,7 @@ func (p *AppPlayer) advanceTo(hasNextTrack bool, seed []string, drop bool, then 
 			return
 		}
 
-		p.advanceNext(true, drop, then)
+		p.advanceNext(true, drop, 0, then)
 	})
 }
 

--- a/daemon/controls_test.go
+++ b/daemon/controls_test.go
@@ -1,0 +1,35 @@
+//go:build test_unit
+
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The first press of a burst loads at once, so a lone skip is as quick as it
+// ever was; only a press that follows another within the window is held back.
+func TestSkipDelay(t *testing.T) {
+	now := time.Now()
+	window := 400 * time.Millisecond
+
+	cases := []struct {
+		name     string
+		debounce time.Duration
+		lastSkip time.Time
+		want     time.Duration
+	}{
+		{"disabled never delays", 0, now, 0},
+		{"first skip is immediate", window, time.Time{}, 0},
+		{"skip after quiet period is immediate", window, now.Add(-time.Second), 0},
+		{"skip right after previous is held", window, now.Add(-100 * time.Millisecond), window},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, skipDelay(tc.debounce, now, tc.lastSkip))
+		})
+	}
+}

--- a/daemon/loader.go
+++ b/daemon/loader.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"time"
 
@@ -48,6 +49,9 @@ func (r replyTo) done(data any, err error) {
 func (p *AppPlayer) applyLoaderResult(res loaderResult) {
 	if res.class == classLoad && res.gen == p.loadGen {
 		p.loadInFlight = false
+		if res.err == nil {
+			p.forgetReplacedStreamEvents()
+		}
 		defer p.drainPendingPlayerEvents()
 	}
 
@@ -185,14 +189,32 @@ func (p *AppPlayer) drainPendingPlayerEvents() {
 	}
 }
 
+// forgetReplacedStreamEvents drops the held events that reported the outgoing
+// stream ending. It kept playing while its replacement loaded, and if it ran
+// out in the meantime its end is held here; handling that against the stream
+// that just landed would advance straight past it.
+func (p *AppPlayer) forgetReplacedStreamEvents() {
+	p.pendingPlayerEvents = slices.DeleteFunc(p.pendingPlayerEvents, func(ev player.Event) bool {
+		return ev.Type == player.EventTypeNotPlaying || ev.Type == player.EventTypeStop
+	})
+}
+
 type loaderClass uint8
 
 const (
-	// classLoad is user-visible track and context work. A new one cancels
-	// whatever is running and drops whatever is queued: only the newest
-	// destination matters, and running the others first is exactly the burst of
-	// skipping this lane exists to prevent.
+	// classLoad is user-visible track and context work with an absolute
+	// destination: a context, a chosen track, the track the pointer is on. A
+	// new one cancels whatever is running and drops whatever is queued: only
+	// the newest destination matters, and running the others first is exactly
+	// the burst of skipping this lane exists to prevent.
 	classLoad loaderClass = iota
+
+	// classNav is relative navigation: one step forward or back from wherever
+	// the pointer is. Dropping a step would change where a burst of them ends
+	// up, so it is queued like a mutation; but the track being loaded or
+	// prefetched is no longer the destination, so it cancels and drops those
+	// like a load. The load it ends in is a classLoad of its own.
+	classNav
 
 	// classMutate changes the track list without loading any media. It is never
 	// dropped and cancels nothing: losing a queued track would be visible.
@@ -230,6 +252,11 @@ type loaderJob struct {
 	gen   uint64
 	reply replyTo
 	run   func(ctx context.Context) loaderResult
+
+	// notBefore holds the job in the queue until then. A load that waits there
+	// can still be dropped by the next one without having cost anything, which
+	// is how a burst of skips is made to pay for one load rather than each.
+	notBefore time.Time
 }
 
 // loaderResult is what comes back to the player loop. commit performs the state
@@ -300,7 +327,7 @@ func (l *loaderLane) submit(job loaderJob) {
 	}
 
 	switch job.class {
-	case classLoad:
+	case classLoad, classNav:
 		dropped = l.dropLoadsLocked()
 	case classPrefetch:
 		if l.hasPendingLoad() {
@@ -337,17 +364,29 @@ func (l *loaderLane) submit(job loaderJob) {
 
 // dropLoadsLocked cancels the load or prefetch in flight and removes those
 // queued, returning them so the caller can answer them once the lock is
-// released. Mutations are left alone: they cancel nothing and are never
-// dropped. Called with the lock held.
+// released. Mutations and navigation are left alone: they cancel nothing and
+// are never dropped. Called with the lock held.
 func (l *loaderLane) dropLoadsLocked() []loaderJob {
 	var dropped []loaderJob
 	dropped, l.queue = partitionQueue(l.queue, func(q loaderJob) bool {
-		return q.class == classLoad || q.class == classPrefetch
+		return q.class.fetches()
 	})
-	if l.running != nil && l.running.class != classMutate {
+	if l.running != nil && l.running.class.fetches() {
 		l.running.cancel()
 	}
 	return dropped
+}
+
+// fetches reports whether a job of this class pulls media, which is the work
+// worth abandoning once its destination changes.
+func (c loaderClass) fetches() bool {
+	return c == classLoad || c == classPrefetch
+}
+
+// loads reports whether a job of this class decides what plays next, and so
+// makes fetching ahead of it pointless.
+func (c loaderClass) loads() bool {
+	return c == classLoad || c == classNav
 }
 
 // dropLoads abandons every load and prefetch, running or queued, for a caller
@@ -365,15 +404,15 @@ func (l *loaderLane) dropLoads() {
 	replyAll(dropped, ErrSuperseded)
 }
 
-// hasPendingLoad reports whether a load is queued or running. Called with the
-// lock held.
+// hasPendingLoad reports whether a load, or the navigation that ends in one, is
+// queued or running. Called with the lock held.
 func (l *loaderLane) hasPendingLoad() bool {
-	if l.running != nil && l.running.class == classLoad {
+	if l.running != nil && l.running.class.loads() {
 		return true
 	}
 
 	for _, q := range l.queue {
-		if q.class == classLoad {
+		if q.class.loads() {
 			return true
 		}
 	}
@@ -399,21 +438,27 @@ func partitionQueue(jobs []loaderJob, drop func(loaderJob) bool) (dropped, kept 
 	return dropped, kept
 }
 
-func (l *loaderLane) next() (loaderJob, context.Context, bool) {
+// next takes the job at the head of the queue, or reports how long until it may
+// be taken: a job whose time has not come stays queued, where a newer one can
+// still drop it.
+func (l *loaderLane) next() (loaderJob, context.Context, time.Duration, bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	if l.closed || len(l.queue) == 0 {
-		return loaderJob{}, nil, false
+		return loaderJob{}, nil, 0, false
 	}
 
 	job := l.queue[0]
+	if wait := time.Until(job.notBefore); wait > 0 {
+		return loaderJob{}, nil, wait, false
+	}
 	l.queue = l.queue[1:]
 
 	ctx, cancel := context.WithTimeout(l.ctx, job.class.timeout())
 	l.running = &runningJob{class: job.class, cancel: cancel}
 
-	return job, ctx, true
+	return job, ctx, 0, true
 }
 
 func (l *loaderLane) execute(job loaderJob, ctx context.Context) loaderResult {
@@ -438,10 +483,19 @@ func (l *loaderLane) run() {
 	defer close(l.done)
 
 	for {
-		job, ctx, ok := l.next()
+		job, ctx, wait, ok := l.next()
 		if !ok {
+			// A nil channel never fires, so with nothing held back this only
+			// wakes for a submit.
+			var ready <-chan time.Time
+			if wait > 0 {
+				ready = time.After(wait)
+			}
+
 			select {
 			case <-l.wake:
+				continue
+			case <-ready:
 				continue
 			case <-l.ctx.Done():
 				return

--- a/daemon/loader_test.go
+++ b/daemon/loader_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	librespot "github.com/devgianlu/go-librespot"
+	"github.com/devgianlu/go-librespot/player"
 	"github.com/stretchr/testify/require"
 )
 
@@ -124,6 +125,196 @@ func TestLoaderPrefetchYieldsToAPendingLoad(t *testing.T) {
 	err, called := answered()
 	require.True(t, called)
 	require.NoError(t, err, "yielding is not a failure")
+}
+
+// A step forward or back is not a destination: dropping one changes where the
+// burst ends up, so navigation is queued through later navigation and loads
+// alike, while a load queued ahead of it is no longer wanted.
+func TestLoaderNavigationIsNotDroppedByLaterWork(t *testing.T) {
+	l := newTestLoaderLane()
+
+	loadReply, loadAnswered := recordingReply(t)
+	navReply, navAnswered := recordingReply(t)
+
+	l.submit(idleJob("load a", classLoad, loadReply))
+	l.submit(idleJob("next", classNav, navReply))
+	l.submit(idleJob("next", classNav, noReply))
+	l.submit(idleJob("load b", classLoad, noReply))
+
+	require.Equal(t, []string{"next", "next", "load b"}, queuedNames(l))
+
+	err, answered := loadAnswered()
+	require.True(t, answered, "the load ahead of a skip is no longer wanted")
+	require.ErrorIs(t, err, ErrSuperseded)
+
+	_, answered = navAnswered()
+	require.False(t, answered, "a queued skip is never dropped")
+}
+
+// The load in flight was fetching a track the pointer is about to leave, so a
+// skip cancels it like a load would; a walk in flight is a step that must
+// still be taken, so nothing cancels that.
+func TestLoaderNavigationCancelsOnlyFetches(t *testing.T) {
+	l := newTestLoaderLane()
+
+	loadCtx, cancel := context.WithCancel(context.Background())
+	l.running = &runningJob{class: classLoad, cancel: cancel}
+	l.submit(idleJob("next", classNav, noReply))
+	require.ErrorIs(t, loadCtx.Err(), context.Canceled, "the running load was not cancelled by a skip")
+
+	navCtx, cancel := context.WithCancel(context.Background())
+	l.running = &runningJob{class: classNav, cancel: cancel}
+	l.submit(idleJob("next", classNav, noReply))
+	l.submit(idleJob("load", classLoad, noReply))
+	require.NoError(t, navCtx.Err(), "a walk in flight is never cancelled")
+}
+
+// Regression: relative walks used to be plain loads, so a press that arrived
+// while the previous one was still queued dropped it, and a burst of twenty
+// presses could end fewer than twenty tracks on. Every queued step must run,
+// in order.
+func TestLoaderBackToBackSkipsBothStep(t *testing.T) {
+	l := newLoaderLane(&librespot.NullLogger{})
+	t.Cleanup(l.close)
+
+	var (
+		mu    sync.Mutex
+		steps []string
+	)
+	step := func(name string) loaderJob {
+		return loaderJob{
+			name:  name,
+			class: classNav,
+			run: func(context.Context) loaderResult {
+				mu.Lock()
+				defer mu.Unlock()
+				steps = append(steps, name)
+				return loaderResult{}
+			},
+		}
+	}
+
+	l.submit(step("first"))
+	l.submit(step("second"))
+
+	for range 2 {
+		select {
+		case <-l.results:
+		case <-time.After(5 * time.Second):
+			t.Fatal("a queued skip never ran")
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"first", "second"}, steps)
+}
+
+// A held load stays queued until its time, and only then is taken.
+func TestLoaderHeldLoadWaitsForItsTime(t *testing.T) {
+	l := newTestLoaderLane()
+
+	held := idleJob("load", classLoad, noReply)
+	held.notBefore = time.Now().Add(time.Hour)
+	l.submit(held)
+
+	_, _, wait, ok := l.next()
+	require.False(t, ok)
+	require.Greater(t, wait, time.Duration(0), "the lane must be told when to look again")
+	require.Equal(t, []string{"load"}, queuedNames(l), "a held load stays queued")
+
+	l.queue[0].notBefore = time.Now().Add(-time.Second)
+	_, _, _, ok = l.next()
+	require.True(t, ok, "a load whose time has come is taken")
+}
+
+// The point of holding a load: the next press, or stopping playback, drops it
+// before it has cost anything.
+func TestLoaderHeldLoadIsDroppedUnstarted(t *testing.T) {
+	for name, supersede := range map[string]func(*loaderLane){
+		"by a skip": func(l *loaderLane) { l.submit(idleJob("next", classNav, noReply)) },
+		"by a load": func(l *loaderLane) { l.submit(idleJob("load b", classLoad, noReply)) },
+		"by a stop": func(l *loaderLane) { l.dropLoads() },
+	} {
+		t.Run(name, func(t *testing.T) {
+			l := newTestLoaderLane()
+
+			reply, answered := recordingReply(t)
+			held := idleJob("load a", classLoad, reply)
+			held.notBefore = time.Now().Add(time.Hour)
+			l.submit(held)
+
+			supersede(l)
+
+			require.NotContains(t, queuedNames(l), "load a")
+
+			err, called := answered()
+			require.True(t, called, "a dropped job still owes its caller an answer")
+			require.ErrorIs(t, err, ErrSuperseded)
+		})
+	}
+}
+
+// Nothing arrives to wake the lane while a load is held, so it has to wake
+// itself once the time comes.
+func TestLoaderHeldLoadRunsOnceItsTimeComes(t *testing.T) {
+	l := newLoaderLane(&librespot.NullLogger{})
+	t.Cleanup(l.close)
+
+	notBefore := time.Now().Add(50 * time.Millisecond)
+
+	var started time.Time
+	l.submit(loaderJob{
+		name:      "load",
+		class:     classLoad,
+		notBefore: notBefore,
+		run: func(context.Context) loaderResult {
+			started = time.Now()
+			return loaderResult{}
+		},
+	})
+
+	select {
+	case <-l.results:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the held load never ran")
+	}
+
+	require.False(t, started.Before(notBefore), "the load ran before its time")
+}
+
+// A load still held at shutdown owes its caller an answer like anything else
+// queued.
+func TestLoaderCloseAnswersAHeldLoad(t *testing.T) {
+	l := newLoaderLane(&librespot.NullLogger{})
+
+	reply, answered := recordingReply(t)
+	held := idleJob("load", classLoad, reply)
+	held.notBefore = time.Now().Add(time.Hour)
+	l.submit(held)
+
+	l.close()
+
+	err, called := answered()
+	require.True(t, called)
+	require.ErrorIs(t, err, ErrNoSession)
+}
+
+// A skip ends in a load, so fetching ahead while one is queued is as pointless
+// as with a load queued.
+func TestLoaderPrefetchYieldsToQueuedNavigation(t *testing.T) {
+	l := newTestLoaderLane()
+
+	reply, answered := recordingReply(t)
+
+	l.submit(idleJob("next", classNav, noReply))
+	l.submit(idleJob("prefetch a", classPrefetch, reply))
+
+	require.Equal(t, []string{"next"}, queuedNames(l))
+
+	err, called := answered()
+	require.True(t, called)
+	require.NoError(t, err)
 }
 
 // Submitting must never wait on the job in flight: the caller is the player loop.
@@ -289,6 +480,41 @@ func TestApplyLoaderResultKeepsLoadAcrossPrefetchInvalidation(t *testing.T) {
 	require.False(t, prefetchCommitted)
 	require.True(t, loadCommitted, "the load is still wanted")
 	require.False(t, p.loadInFlight)
+}
+
+// The outgoing stream kept playing while its replacement loaded. If it ran out
+// meanwhile, the events reporting that were held for the load; handling them
+// once it lands would advance past the track that just started. The handlers
+// need a session, so if either event were drained here the test would panic.
+func TestApplyLoaderResultForgetsTheReplacedStreamsEnd(t *testing.T) {
+	p := &AppPlayer{app: &App{log: &librespot.NullLogger{}}, loadGen: 1, loadInFlight: true}
+	p.pendingPlayerEvents = []player.Event{{Type: player.EventTypeNotPlaying}, {Type: player.EventTypeStop}}
+
+	var committed bool
+	p.applyLoaderResult(loaderResult{
+		class:  classLoad,
+		gen:    1,
+		commit: func(*AppPlayer, error) { committed = true },
+	})
+
+	require.True(t, committed)
+	require.False(t, p.loadInFlight)
+	require.Empty(t, p.pendingPlayerEvents)
+}
+
+// Only the end of the outgoing stream is forgotten: a play or pause that
+// arrived during the load describes what the listener asked for meanwhile.
+func TestForgetReplacedStreamEventsKeepsTheRest(t *testing.T) {
+	p := &AppPlayer{pendingPlayerEvents: []player.Event{
+		{Type: player.EventTypePlay},
+		{Type: player.EventTypeNotPlaying},
+		{Type: player.EventTypePause},
+		{Type: player.EventTypeStop},
+	}}
+
+	p.forgetReplacedStreamEvents()
+
+	require.Equal(t, []player.Event{{Type: player.EventTypePlay}, {Type: player.EventTypePause}}, p.pendingPlayerEvents)
 }
 
 // A job that failed still reaches its commit, so whoever asked for the load

--- a/daemon/player.go
+++ b/daemon/player.go
@@ -69,6 +69,10 @@ type AppPlayer struct {
 	loadInFlight        bool
 	pendingPlayerEvents []player.Event
 
+	// lastSkipAt is when the previous next or prev was pressed; a press that
+	// follows it within SkipDebounce is part of a burst.
+	lastSkipAt time.Time
+
 	statePush         *statePushLane
 	stateTimer        *time.Timer
 	stateDirty        bool


### PR DESCRIPTION
Closes the first half of [#346](https://github.com/palchrb/go-librespot/issues/346).

A burst of next/prev presses currently loads every track it passes through — one audio-key request per press — and Spotify answers 429 well before the listener finds their song. This splits the skip into a pointer move and a deferred load: presses move the selection immediately (published via will_play and a new pending_track_uri in /status), and only the track the user stops on gets loaded.

The window (skip_debounce_ms, default 600, 0 disables) was measured, not guessed: across two sessions of continuous skipping from the Spotify iOS app, gaps between Connect commands ranged 74–495ms. Deferred pointer moves also skip the connect-state PUT (only the first of a burst publishes) — the burst otherwise outruns the endpoint's tolerance and reproduces the same 429 on a different endpoint. Field-tested on a Pi Zero 2 W: a 20-press burst now costs 2 loads and no rate limiting.