### PR TITLE
Feat/windows compile

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -59,3 +59,121 @@ jobs:
           name: coverage
           path: coverage.out.filtered
           if-no-files-found: error
+
+  windows:
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.25'
+
+      - name: Install MinGW and decode libraries
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: false
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-libogg
+            mingw-w64-x86_64-libvorbis
+            mingw-w64-x86_64-flac
+            mingw-w64-x86_64-mpg123
+          path-type: inherit
+
+      - name: Configure CGO for MSYS2
+        run: |
+          # go.exe is a native Windows binary. Convert MSYS2 paths so CGO
+          # does not pick Strawberry Perl's pkg-config or a missing C:\msys64.
+          {
+            echo "CC=$(cygpath -m "$(command -v gcc)")"
+            echo "PKG_CONFIG=$(cygpath -m "$(command -v pkg-config)")"
+            echo "PKG_CONFIG_PATH=$(cygpath -m /mingw64/lib/pkgconfig)"
+          } >> "$GITHUB_ENV"
+          # libogg.dll.a is generated from win32/ogg.def, which omits
+          # ogg_stream_iovecin (required by xlab/vorbis-go). Hide the import
+          # lib so -logg resolves to libogg.a. Leave FLAC/mpg123/vorbis as DLLs
+          # to avoid duplicate symbols and extra Win32 deps (shlwapi).
+          if [ -f /mingw64/lib/libogg.dll.a ]; then
+            mv /mingw64/lib/libogg.dll.a /mingw64/lib/libogg.dll.a.unused
+          fi
+
+      - name: Build daemon
+        env:
+          CGO_ENABLED: 1
+        run: |
+          export PATH="/mingw64/bin:${PATH}"
+          go build -v -o go-librespot.exe ./cmd/daemon
+
+      - name: Test
+        env:
+          CGO_ENABLED: 1
+        run: |
+          export PATH="/mingw64/bin:${PATH}"
+          go test -v -tags "test_unit test_integration" ./...
+
+      - name: Upload Windows binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-librespot-windows-amd64
+          path: go-librespot.exe
+          retention-days: 7
+          if-no-files-found: error
+
+  windows-vcpkg:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.25'
+
+      - name: Install MinGW cross compiler
+        run: sudo apt-get update && sudo apt-get install -y gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config curl zip unzip tar
+
+      - name: Cache vcpkg
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/vcpkg
+            vcpkg_installed
+          key: vcpkg-mingw-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg-triplets/**') }}
+
+      - name: Bootstrap vcpkg
+        run: |
+          if [ ! -x /tmp/vcpkg/vcpkg ]; then
+            git clone --depth 1 --branch 2025.09.17 https://github.com/microsoft/vcpkg.git /tmp/vcpkg
+            /tmp/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+          fi
+
+      - name: Install decode libraries
+        env:
+          VCPKG_ROOT: /tmp/vcpkg
+        run: /tmp/vcpkg/vcpkg install --triplet x64-mingw-static
+
+      - name: Cross-compile Windows daemon
+        env:
+          CGO_ENABLED: 1
+          GOOS: windows
+          GOARCH: amd64
+          CC: x86_64-w64-mingw32-gcc
+          CGO_LDFLAGS: -static
+          PKG_CONFIG_LIBDIR: ${{ github.workspace }}/vcpkg_installed/x64-mingw-static/lib/pkgconfig
+          PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-mingw-static/lib/pkgconfig
+        run: go build -v -o go-librespot.exe -ldflags "-s -w" ./cmd/daemon
+
+      - name: Upload vcpkg Windows binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-librespot-windows-amd64-vcpkg
+          path: go-librespot.exe
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,68 @@ jobs:
           path: /tmp/out
           retention-days: 7
 
+  build-windows:
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.25'
+
+      - name: Install MinGW and decode libraries
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: false
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-libogg
+            mingw-w64-x86_64-libvorbis
+            mingw-w64-x86_64-flac
+            mingw-w64-x86_64-mpg123
+          path-type: inherit
+
+      - name: Configure CGO for MSYS2
+        run: |
+          {
+            echo "CC=$(cygpath -m "$(command -v gcc)")"
+            echo "PKG_CONFIG=$(cygpath -m "$(command -v pkg-config)")"
+            echo "PKG_CONFIG_PATH=$(cygpath -m /mingw64/lib/pkgconfig)"
+          } >> "$GITHUB_ENV"
+          # libogg.dll.a omits ogg_stream_iovecin; force -logg onto libogg.a.
+          if [ -f /mingw64/lib/libogg.dll.a ]; then
+            mv /mingw64/lib/libogg.dll.a /mingw64/lib/libogg.dll.a.unused
+          fi
+
+      - name: Compile Windows binary
+        env:
+          CGO_ENABLED: 1
+        run: |
+          export PATH="/mingw64/bin:${PATH}"
+          mkdir -p out
+          go build -o go-librespot.exe -ldflags "-s -w" ./cmd/daemon
+          tar -zcvf out/go-librespot_windows_amd64.tar.gz go-librespot.exe README.md
+
+      - name: Upload compiled binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-windows_amd64
+          path: out
+          retention-days: 7
+
   publish:
     runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - build
+      - build-windows
     steps:
       - name: Download compiled binaries
         uses: actions/download-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 # Coverage
 coverage.out
 coverage.out.filtered
+*.exe
+.commandcode

--- a/CROSS_COMPILE.md
+++ b/CROSS_COMPILE.md
@@ -24,3 +24,25 @@ The `armv6` variant is a generic armv6 build. It should work on most armv6 devic
 
 The `armv6_rpi` variant is specifically built for the Raspberry Pi 1 and Zero, which do not support thumb instructions.
 The toolchain used for this build can be found [here](https://github.com/devgianlu/rpi-toolchain).
+
+## Windows (native C libraries)
+
+Windows builds need the same decode libraries as Linux (`libogg`, `libvorbis`, `libflac`, `mpg123`) compiled with MinGW so they can be linked through CGO. ALSA is Linux-only and is skipped automatically.
+
+From a checkout that already has vcpkg bootstrapped:
+
+```shell
+vcpkg install --triplet x64-mingw-static
+```
+
+The overlay triplet lives in [`vcpkg-triplets/x64-mingw-static.cmake`](./vcpkg-triplets/x64-mingw-static.cmake). Point CGO at the installed pkg-config files:
+
+```
+PKG_CONFIG_PATH=<repo>/vcpkg_installed/x64-mingw-static/lib/pkgconfig
+CGO_ENABLED=1
+CC=x86_64-w64-mingw32-gcc
+```
+
+The Windows default `audio_backend` is `wasapi`: a first-party shared-mode WASAPI driver (default playback device, software volume). It does not use `go-wca`.
+
+CI compiles `windows/amd64` two ways: natively on `windows-2022` (MSYS2 packages) and by cross-compiling from Ubuntu with this vcpkg triplet. PR artifacts are uploaded as `go-librespot-windows-amd64` and `go-librespot-windows-amd64-vcpkg`. Tagged releases include `go-librespot_windows_amd64.tar.gz`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## Features
 
 - 🎵 **Spotify Connect** — show up as a speaker in the Spotify app and stream to it from any device on your network (Spotify Premium required).
-- 🔊 **Multiple audio backends** — ALSA, PulseAudio, or a raw named pipe for custom routing.
+- 🔊 **Multiple audio backends** — ALSA, PulseAudio, WASAPI on Windows, or a raw named pipe for custom routing.
 - 📊 **Loudness normalization** — Spotify-standard −14 LUFS (ITU-R BS.1770) with configurable pregain.
 - 🔀 **Crossfade** — configurable overlap between consecutive tracks.
 - 🎙️ **Podcast resume** — episodes pick up where you left off, and progress syncs back to your other devices.
@@ -66,7 +66,7 @@ brew install go-librespot
 To build from source the following prerequisites are necessary:
 
 - Go 1.25 or higher
-- Libraries: `libogg`, `libvorbis`, `flac`, `mpg123`, `libasound2`
+- Libraries: `libogg`, `libvorbis`, `flac`, `mpg123` (plus `libasound2` on Linux)
 
 To install Go, download it from the [Go website](https://go.dev/dl/).
 
@@ -75,6 +75,14 @@ To install the required libraries on Debian-based systems (Debian, Ubuntu, Raspb
 ```shell
 sudo apt-get install libogg-dev libvorbis-dev libflac-dev libmpg123-dev libasound2-dev
 ```
+
+On Windows the default backend is WASAPI (default playback device). Install the decode libraries as MinGW packages (MSVC `.lib` files will not link with CGO), for example with [MSYS2](https://www.msys2.org/):
+
+```
+pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123
+```
+
+Cross-compiling a static `windows/amd64` binary with vcpkg is described in [CROSS_COMPILE.md](/CROSS_COMPILE.md).
 
 Once prerequisites are installed you can clone the repository and run the daemon with:
 
@@ -86,8 +94,8 @@ Details about cross-compiling go-librespot are described [here](/CROSS_COMPILE.m
 
 ## Configuration
 
-The default directory for configuration files is `~/.config/go-librespot`. On macOS devices, this is
-`~/Library/Application Support/go-librespot`. You can change this directory with the
+The default directory for configuration files is `~/.config/go-librespot`. On macOS this is
+`~/Library/Application Support/go-librespot`. On Windows it is `%APPDATA%\go-librespot`. You can change this directory with the
 `-config_dir` flag. The configuration directory contains:
 
 - `config.yml`: The main configuration (does not exist by default)
@@ -242,7 +250,7 @@ log_disable_timestamp: false # Whether to disable timestamps in log output
 device_id: '' # Spotify device ID (auto-generated)
 device_name: '' # Spotify device name
 device_type: computer # Spotify device type (icon)
-audio_backend: alsa # Audio backend to use (alsa, pipe, pulseaudio)
+audio_backend: alsa # Audio backend to use (alsa, pipe, pulseaudio, audio-toolbox, wasapi). Default is alsa, or wasapi on Windows.
 audio_backend_runtime_socket: '' # Audio backends' runtime socket to use, if backend is pulseaudio
 audio_device: default # ALSA audio device to use for playback
 mixer_device: '' # ALSA mixer device for volume synchronization 

--- a/audio/chunked-reader_integration_test.go
+++ b/audio/chunked-reader_integration_test.go
@@ -255,18 +255,15 @@ func (suite *HttpChunkedReaderIntegrationSuite) TestLatencyMetrics() {
 		suite.Require().NoError(err)
 	}
 
-	// Check that latency metrics are reasonable
-	suite.Greater(reader.InitialLatency(), time.Duration(0))
-	suite.Greater(reader.MaxLatency(), time.Duration(0))
-	suite.Greater(reader.MinLatency(), time.Duration(0))
-	suite.Greater(reader.AvgLatencyMs(), 0.0)
-	suite.Greater(reader.MedianLatency(), time.Duration(0))
-	suite.Greater(reader.TotalTime(), time.Duration(0))
-
-	// Sanity checks
-	suite.LessOrEqual(reader.MinLatency(), reader.MaxLatency())
-	suite.LessOrEqual(reader.MinLatency(), reader.MedianLatency())
+	// Samples may be 0 on Windows: localhost httptest can finish inside
+	// one clock tick, so time.Since returns 0. Check consistency instead.
+	suite.GreaterOrEqual(reader.InitialLatency(), time.Duration(0))
+	suite.GreaterOrEqual(reader.MinLatency(), time.Duration(0))
+	suite.GreaterOrEqual(reader.AvgLatencyMs(), 0.0)
+	suite.GreaterOrEqual(reader.MaxLatency(), reader.MinLatency())
+	suite.GreaterOrEqual(reader.MedianLatency(), reader.MinLatency())
 	suite.LessOrEqual(reader.MedianLatency(), reader.MaxLatency())
+	suite.GreaterOrEqual(reader.TotalTime(), reader.MaxLatency())
 }
 
 func (suite *HttpChunkedReaderIntegrationSuite) TestErrorRecovery() {

--- a/cache/limiter_test.go
+++ b/cache/limiter_test.go
@@ -38,10 +38,12 @@ func TestEvictsLeastRecentlyUsed(t *testing.T) {
 	_, ok = c.File(b)
 	require.False(t, ok, "least recently used file should have been evicted")
 
-	_, ok = c.File(a)
+	r, ok = c.File(a)
 	require.True(t, ok, "recently used file should be retained")
-	_, ok = c.File(d)
+	_ = r.(interface{ Close() error }).Close()
+	r, ok = c.File(d)
 	require.True(t, ok, "newly written file should be retained")
+	_ = r.(interface{ Close() error }).Close()
 
 	require.LessOrEqual(t, c.limiter.inUse, int64(25))
 }
@@ -75,8 +77,9 @@ func TestRecencySurvivesRestart(t *testing.T) {
 
 	_, ok = c2.File(a)
 	require.False(t, ok, "stale file should have been evicted on startup")
-	_, ok = c2.File(b)
+	r, ok = c2.File(b)
 	require.True(t, ok, "recently accessed file should survive a restart")
+	_ = r.(interface{ Close() error }).Close()
 }
 
 func TestNoEvictionWithoutLimit(t *testing.T) {
@@ -89,8 +92,9 @@ func TestNoEvictionWithoutLimit(t *testing.T) {
 	}
 
 	for i := 0; i < 20; i++ {
-		_, ok := c.File([]byte{byte(i), 0xff})
+		r, ok := c.File([]byte{byte(i), 0xff})
 		require.True(t, ok)
+		_ = r.(interface{ Close() error }).Close()
 	}
 }
 

--- a/cmd/daemon/cli_config.go
+++ b/cmd/daemon/cli_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -196,7 +197,7 @@ func loadCLIConfig(cfg *cliConfig) error {
 		"device_type": "computer",
 		"bitrate":     160,
 
-		"audio_backend":            "alsa",
+		"audio_backend":            defaultAudioBackend(),
 		"audio_device":             "default",
 		"audio_output_pipe_format": "s16le",
 		"mixer_control_name":       "Master",
@@ -269,6 +270,13 @@ func loadCLIConfig(cfg *cliConfig) error {
 	}
 
 	return nil
+}
+
+func defaultAudioBackend() string {
+	if runtime.GOOS == "windows" {
+		return "wasapi"
+	}
+	return "alsa"
 }
 
 // parseSize parses a human-readable size string such as "1GB", "500MB" or a

--- a/cmd/daemon/cli_config_test.go
+++ b/cmd/daemon/cli_config_test.go
@@ -5,10 +5,20 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestDefaultAudioBackend(t *testing.T) {
+	got := defaultAudioBackend()
+	if runtime.GOOS == "windows" {
+		require.Equal(t, "wasapi", got)
+		return
+	}
+	require.Equal(t, "alsa", got)
+}
 
 func TestParseSize(t *testing.T) {
 	cases := []struct {
@@ -57,5 +67,10 @@ func TestLoadCLIConfigWaitForReaderFlag(t *testing.T) {
 
 	cfg := &cliConfig{}
 	require.NoError(t, loadCLIConfig(cfg))
+	t.Cleanup(func() {
+		if cfg.configLock != nil {
+			_ = cfg.configLock.Unlock()
+		}
+	})
 	require.True(t, cfg.AudioOutputPipeWaitForReader, "audio_output_pipe_wait_for_reader was not parsed from the config file")
 }

--- a/cmd/daemon/file_state_store.go
+++ b/cmd/daemon/file_state_store.go
@@ -70,14 +70,37 @@ func (s *FileStateStore) Save(state *librespot.AppState) error {
 	if err != nil {
 		return fmt.Errorf("failed creating temporary file for app state: %w", err)
 	}
+	tmpPath := tmpFile.Name()
 
 	if err := json.NewEncoder(tmpFile).Encode(state); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed writing marshalled app state: %w", err)
 	}
 
-	if err := os.Rename(tmpFile.Name(), s.statePath); err != nil {
+	// Windows cannot rename a file that still has an open handle.
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed closing temporary app state file: %w", err)
+	}
+
+	if err := replaceFile(tmpPath, s.statePath); err != nil {
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed replacing app state file: %w", err)
 	}
 
 	return nil
+}
+
+// replaceFile moves src onto dest. On Windows, os.Rename cannot overwrite an
+// existing dest, so dest is removed first. The daemon holds a lockfile, so
+// nothing else should be rewriting this path.
+func replaceFile(src, dest string) error {
+	if err := os.Rename(src, dest); err == nil {
+		return nil
+	}
+	if err := os.Remove(dest); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return os.Rename(src, dest)
 }

--- a/cmd/daemon/file_state_store_test.go
+++ b/cmd/daemon/file_state_store_test.go
@@ -1,0 +1,32 @@
+//go:build test_unit
+
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	librespot "github.com/devgianlu/go-librespot"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileStateStoreSaveReplacesExisting(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileStateStore(filepath.Join(dir, "state.json"), filepath.Join(dir, "credentials.json"), &librespot.NullLogger{})
+
+	first := &librespot.AppState{}
+	first.DeviceId = "device-1"
+	require.NoError(t, store.Save(first))
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	require.Equal(t, "device-1", loaded.DeviceId)
+
+	second := &librespot.AppState{}
+	second.DeviceId = "device-2"
+	require.NoError(t, store.Save(second))
+
+	loaded, err = store.Load()
+	require.NoError(t, err)
+	require.Equal(t, "device-2", loaded.DeviceId)
+}

--- a/config_schema.json
+++ b/config_schema.json
@@ -71,7 +71,9 @@
           "enum": [
             "alsa",
             "pulseaudio",
-            "pipe"
+            "pipe",
+            "audio-toolbox",
+            "wasapi"
           ],
           "default": "alsa"
         },

--- a/output/driver-alsa-stub.go
+++ b/output/driver-alsa-stub.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build android || darwin || js || windows || nintendosdk
 
 package output
 
@@ -7,5 +7,5 @@ import (
 )
 
 func newAlsaOutput(opts *NewOutputOptions) (Output, error) {
-	return nil, fmt.Errorf("alsa output is not supported on MacOS")
+	return nil, fmt.Errorf("alsa output is not supported on this platform")
 }

--- a/output/driver-pipe-stub.go
+++ b/output/driver-pipe-stub.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package output
+
+import (
+	"fmt"
+)
+
+func newPipeOutput(opts *NewOutputOptions) (Output, error) {
+	return nil, fmt.Errorf("pipe output is not supported on Windows")
+}

--- a/output/driver-pipe-unix.go
+++ b/output/driver-pipe-unix.go
@@ -1,0 +1,52 @@
+//go:build !windows
+
+package output
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+)
+
+func newPipeOutput(opts *NewOutputOptions) (out *pipeOutput, err error) {
+	out = &pipeOutput{
+		reader:         opts.Reader,
+		volume:         opts.InitialVolume,
+		err:            make(chan error, 2),
+		externalVolume: opts.ExternalVolume,
+		volumeUpdate:   opts.VolumeUpdate,
+	}
+
+	out.cond = sync.NewCond(&out.lock)
+
+	out.transform, err = newPipeTransform(opts.OutputPipeFormat)
+	if err != nil {
+		return nil, err
+	}
+
+	// Open the FIFO for writing. When not waiting for a reader, open it as
+	// non-blocking to cause an error if there is no reader. When waiting for a
+	// reader (e.g. snapcast with dryout), the blocking open will wait until a
+	// reader connects.
+	flags := os.O_WRONLY
+	if !opts.OutputPipeWaitForReader {
+		flags |= syscall.O_NONBLOCK
+	}
+
+	out.file, err = os.OpenFile(opts.OutputPipe, flags, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open fifo: %w", err)
+	}
+
+	if !opts.OutputPipeWaitForReader {
+		// Restore blocking mode now that we are sure we have a reader.
+		if err := syscall.SetNonblock(int(out.file.Fd()), false); err != nil {
+			return nil, fmt.Errorf("failed to set blocking mode on fifo: %w", err)
+		}
+	}
+
+	go out.outputLoop()
+
+	return out, nil
+}

--- a/output/driver-pipe.go
+++ b/output/driver-pipe.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"os"
 	"sync"
-	"syscall"
 
 	librespot "github.com/devgianlu/go-librespot"
 )
@@ -75,48 +74,6 @@ func newPipeTransform(format string) (func([]float32, []byte) int, error) {
 	default:
 		return nil, fmt.Errorf("unknown output pipe format: %s", format)
 	}
-}
-
-func newPipeOutput(opts *NewOutputOptions) (out *pipeOutput, err error) {
-	out = &pipeOutput{
-		reader:         opts.Reader,
-		volume:         opts.InitialVolume,
-		err:            make(chan error, 2),
-		externalVolume: opts.ExternalVolume,
-		volumeUpdate:   opts.VolumeUpdate,
-	}
-
-	out.cond = sync.NewCond(&out.lock)
-
-	out.transform, err = newPipeTransform(opts.OutputPipeFormat)
-	if err != nil {
-		return nil, err
-	}
-
-	// Open the FIFO for writing. When not waiting for a reader, open it as
-	// non-blocking to cause an error if there is no reader. When waiting for a
-	// reader (e.g. snapcast with dryout), the blocking open will wait until a
-	// reader connects.
-	flags := os.O_WRONLY
-	if !opts.OutputPipeWaitForReader {
-		flags |= syscall.O_NONBLOCK
-	}
-
-	out.file, err = os.OpenFile(opts.OutputPipe, flags, 0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open fifo: %w", err)
-	}
-
-	if !opts.OutputPipeWaitForReader {
-		// Restore blocking mode now that we are sure we have a reader.
-		if err := syscall.SetNonblock(int(out.file.Fd()), false); err != nil {
-			return nil, fmt.Errorf("failed to set blocking mode on fifo: %w", err)
-		}
-	}
-
-	go out.outputLoop()
-
-	return out, nil
 }
 
 func (out *pipeOutput) outputLoop() {

--- a/output/driver-pipe_test.go
+++ b/output/driver-pipe_test.go
@@ -4,13 +4,8 @@ package output
 
 import (
 	"encoding/binary"
-	"io"
 	"math"
-	"os"
-	"path/filepath"
-	"syscall"
 	"testing"
-	"time"
 )
 
 func s16(t *testing.T, in []float32) []int16 {
@@ -145,82 +140,4 @@ func TestPipeTransformUnknownFormat(t *testing.T) {
 	if _, err := newPipeTransform("s24le"); err == nil {
 		t.Fatal("expected an error for an unsupported format")
 	}
-}
-
-// eofReader is a Float32Reader that reports end of stream, so the pipe output
-// loop goes idle and blocks on the cond var instead of writing.
-type eofReader struct{}
-
-func (eofReader) Read([]float32) (int, error) {
-	return 0, io.EOF
-}
-
-func mkfifo(t *testing.T) string {
-	t.Helper()
-
-	path := filepath.Join(t.TempDir(), "test-fifo")
-	if err := syscall.Mkfifo(path, 0o600); err != nil {
-		t.Fatalf("mkfifo: %v", err)
-	}
-	return path
-}
-
-func pipeOutputOptions(path string, waitForReader bool) *NewOutputOptions {
-	return &NewOutputOptions{
-		Reader:                  eofReader{},
-		OutputPipe:              path,
-		OutputPipeFormat:        "s16le",
-		OutputPipeWaitForReader: waitForReader,
-	}
-}
-
-func TestPipeOutputFailsWithoutReader(t *testing.T) {
-	out, err := newPipeOutput(pipeOutputOptions(mkfifo(t), false))
-	if err == nil {
-		out.Close()
-		t.Fatal("expected an error opening the FIFO without a reader")
-	}
-}
-
-func TestPipeOutputWaitsForReader(t *testing.T) {
-	path := mkfifo(t)
-
-	result := make(chan *pipeOutput, 1)
-	errCh := make(chan error, 1)
-	go func() {
-		out, err := newPipeOutput(pipeOutputOptions(path, true))
-		if err != nil {
-			errCh <- err
-			return
-		}
-		result <- out
-	}()
-
-	// The open must wait for a reader instead of failing.
-	select {
-	case out := <-result:
-		out.Close()
-		t.Fatal("expected newPipeOutput to wait for a reader")
-	case err := <-errCh:
-		t.Fatalf("newPipeOutput returned error: %v", err)
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	// Connect a reader: the pending open should now complete.
-	reader, err := os.OpenFile(path, os.O_RDONLY, 0)
-	if err != nil {
-		t.Fatalf("failed opening FIFO for reading: %v", err)
-	}
-	defer reader.Close()
-
-	var out *pipeOutput
-	select {
-	case out = <-result:
-	case err := <-errCh:
-		t.Fatalf("newPipeOutput returned error: %v", err)
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for newPipeOutput to open the FIFO")
-	}
-
-	defer out.Close()
 }

--- a/output/driver-pipe_unix_test.go
+++ b/output/driver-pipe_unix_test.go
@@ -1,0 +1,90 @@
+//go:build test_unit && !windows
+
+package output
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// eofReader is a Float32Reader that reports end of stream, so the pipe output
+// loop goes idle and blocks on the cond var instead of writing.
+type eofReader struct{}
+
+func (eofReader) Read([]float32) (int, error) {
+	return 0, io.EOF
+}
+
+func mkfifo(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test-fifo")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	return path
+}
+
+func pipeOutputOptions(path string, waitForReader bool) *NewOutputOptions {
+	return &NewOutputOptions{
+		Reader:                  eofReader{},
+		OutputPipe:              path,
+		OutputPipeFormat:        "s16le",
+		OutputPipeWaitForReader: waitForReader,
+	}
+}
+
+func TestPipeOutputFailsWithoutReader(t *testing.T) {
+	out, err := newPipeOutput(pipeOutputOptions(mkfifo(t), false))
+	if err == nil {
+		out.Close()
+		t.Fatal("expected an error opening the FIFO without a reader")
+	}
+}
+
+func TestPipeOutputWaitsForReader(t *testing.T) {
+	path := mkfifo(t)
+
+	result := make(chan *pipeOutput, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		out, err := newPipeOutput(pipeOutputOptions(path, true))
+		if err != nil {
+			errCh <- err
+			return
+		}
+		result <- out
+	}()
+
+	// The open must wait for a reader instead of failing.
+	select {
+	case out := <-result:
+		out.Close()
+		t.Fatal("expected newPipeOutput to wait for a reader")
+	case err := <-errCh:
+		t.Fatalf("newPipeOutput returned error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Connect a reader: the pending open should now complete.
+	reader, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("failed opening FIFO for reading: %v", err)
+	}
+	defer reader.Close()
+
+	var out *pipeOutput
+	select {
+	case out = <-result:
+	case err := <-errCh:
+		t.Fatalf("newPipeOutput returned error: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for newPipeOutput to open the FIFO")
+	}
+
+	defer out.Close()
+}

--- a/output/driver-wasapi-stub.go
+++ b/output/driver-wasapi-stub.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package output
+
+import (
+	"fmt"
+)
+
+func newWasapiOutput(opts *NewOutputOptions) (Output, error) {
+	return nil, fmt.Errorf("wasapi output is only supported on Windows")
+}

--- a/output/driver-wasapi.go
+++ b/output/driver-wasapi.go
@@ -1,0 +1,421 @@
+//go:build windows
+
+package output
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	librespot "github.com/devgianlu/go-librespot"
+	"golang.org/x/sys/windows"
+)
+
+const defaultWasapiBufferTimeMicro = 50_000
+
+type wasapiOutput struct {
+	log librespot.Logger
+
+	channels   int
+	sampleRate int
+	reader     librespot.Float32Reader
+
+	lock sync.Mutex
+	cond *sync.Cond
+
+	enumerator *immDeviceEnumerator
+	client     *iAudioClient
+	render     *iAudioRenderClient
+	ready      windows.Handle
+	bufFrames  uint32
+
+	volume         float32
+	externalVolume bool
+	volumeUpdate   chan float32
+
+	paused bool
+	closed bool
+
+	err  chan error
+	done chan struct{}
+}
+
+func newWasapiOutput(opts *NewOutputOptions) (Output, error) {
+	if unsafe.Sizeof(uintptr(0)) != 8 {
+		return nil, fmt.Errorf("wasapi output requires 64-bit Windows")
+	}
+	if opts.Reader == nil {
+		return nil, fmt.Errorf("wasapi output requires a reader")
+	}
+	if opts.SampleRate <= 0 || opts.ChannelCount <= 0 {
+		return nil, fmt.Errorf("wasapi output requires sample rate and channel count")
+	}
+
+	out := &wasapiOutput{
+		log:            opts.Log,
+		channels:       opts.ChannelCount,
+		sampleRate:     opts.SampleRate,
+		reader:         opts.Reader,
+		volume:         opts.InitialVolume,
+		externalVolume: opts.ExternalVolume,
+		volumeUpdate:   opts.VolumeUpdate,
+		err:            make(chan error, 2),
+		done:           make(chan struct{}),
+	}
+	out.cond = sync.NewCond(&out.lock)
+
+	if err := coInitialize(); err != nil {
+		return nil, fmt.Errorf("wasapi: CoInitializeEx: %w", err)
+	}
+
+	ev, err := windows.CreateEventEx(nil, nil, 0, windows.EVENT_ALL_ACCESS)
+	if err != nil {
+		windows.CoUninitialize()
+		return nil, fmt.Errorf("wasapi: CreateEventEx: %w", err)
+	}
+	out.ready = ev
+
+	if err := out.openClient(opts.BufferTimeMicro); err != nil {
+		out.release()
+		windows.CoUninitialize()
+		return nil, err
+	}
+
+	go out.loop()
+
+	if err := out.client.Start(); err != nil {
+		out.lock.Lock()
+		out.closed = true
+		out.cond.Signal()
+		out.lock.Unlock()
+		<-out.done
+		out.release()
+		windows.CoUninitialize()
+		return nil, err
+	}
+
+	// The render loop keeps COM initialized. Drop the constructor thread's
+	// apartment so Close/Pause can run on any goroutine.
+	windows.CoUninitialize()
+
+	if out.log != nil {
+		out.log.Info("started wasapi output")
+	}
+	return out, nil
+}
+
+func (out *wasapiOutput) openClient(bufferTimeMicro int) error {
+	enum, err := coCreateMMDeviceEnumerator()
+	if err != nil {
+		return err
+	}
+	out.enumerator = enum
+
+	dev, err := enum.GetDefaultAudioEndpoint()
+	if err != nil {
+		return err
+	}
+	defer dev.Release()
+
+	client, err := dev.ActivateAudioClient()
+	if err != nil {
+		return err
+	}
+	out.client = client
+
+	if bufferTimeMicro <= 0 {
+		bufferTimeMicro = defaultWasapiBufferTimeMicro
+	}
+	// REFERENCE_TIME is 100ns. 1µs = 10 of those units.
+	if err := client.Initialize(int64(bufferTimeMicro)*10, newFloatFormat(out.sampleRate, out.channels)); err != nil {
+		return err
+	}
+
+	frames, err := client.GetBufferSize()
+	if err != nil {
+		return err
+	}
+	out.bufFrames = frames
+
+	render, err := client.GetRenderClient()
+	if err != nil {
+		return err
+	}
+	out.render = render
+
+	return client.SetEventHandle(out.ready)
+}
+
+func (out *wasapiOutput) loop() {
+	defer close(out.done)
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if err := coInitialize(); err != nil {
+		out.fail(fmt.Errorf("wasapi: render thread CoInitializeEx: %w", err))
+		return
+	}
+	defer windows.CoUninitialize()
+
+	for {
+		out.lock.Lock()
+		for out.paused && !out.closed {
+			out.cond.Wait()
+		}
+		if out.closed {
+			out.lock.Unlock()
+			return
+		}
+		out.lock.Unlock()
+
+		evt, err := windows.WaitForSingleObject(out.ready, 50)
+		if err != nil {
+			out.fail(fmt.Errorf("wasapi: WaitForSingleObject: %w", err))
+			return
+		}
+		if evt == uint32(windows.WAIT_TIMEOUT) {
+			continue
+		}
+		if evt != uint32(windows.WAIT_OBJECT_0) {
+			out.fail(fmt.Errorf("wasapi: WaitForSingleObject returned %d", evt))
+			return
+		}
+
+		if err := out.write(); err != nil {
+			out.fail(err)
+			return
+		}
+	}
+}
+
+func (out *wasapiOutput) write() error {
+	out.lock.Lock()
+	if out.closed || out.paused || out.client == nil || out.render == nil {
+		out.lock.Unlock()
+		return nil
+	}
+	client := out.client
+	render := out.render
+	channels := out.channels
+	volume := out.volume
+	external := out.externalVolume
+	out.lock.Unlock()
+
+	padding, err := client.GetCurrentPadding()
+	if err != nil {
+		return err
+	}
+	frames := out.bufFrames - padding
+	if frames == 0 {
+		return nil
+	}
+
+	samples := make([]float32, int(frames)*channels)
+	n, readErr := out.reader.Read(samples)
+	if n > 0 {
+		n -= n % channels
+	}
+
+	out.lock.Lock()
+	defer out.lock.Unlock()
+	if out.closed || out.paused || out.render != render {
+		return nil
+	}
+
+	if n > 0 && !external {
+		gain := volume * volume
+		for i := 0; i < n; i++ {
+			samples[i] *= gain
+		}
+
+		dst, err := render.GetBuffer(uint32(n / channels))
+		if err != nil {
+			return err
+		}
+		copy(unsafe.Slice((*float32)(unsafe.Pointer(dst)), n), samples[:n])
+		if err := render.ReleaseBuffer(uint32(n / channels)); err != nil {
+			return err
+		}
+	}
+
+	if errors.Is(readErr, io.EOF) {
+		out.paused = true
+		_ = client.Stop()
+		return nil
+	}
+	if readErr != nil {
+		return readErr
+	}
+	return nil
+}
+
+func (out *wasapiOutput) fail(err error) {
+	out.lock.Lock()
+	defer out.lock.Unlock()
+	if out.closed {
+		return
+	}
+	out.closed = true
+	select {
+	case out.err <- err:
+	default:
+	}
+	out.cond.Signal()
+}
+
+func (out *wasapiOutput) Pause() error {
+	return out.withCOM(func() error {
+		out.lock.Lock()
+		defer out.lock.Unlock()
+		if out.closed || out.paused || out.client == nil {
+			return nil
+		}
+		if err := out.client.Stop(); err != nil {
+			return err
+		}
+		out.paused = true
+		out.cond.Signal()
+		return nil
+	})
+}
+
+func (out *wasapiOutput) Resume() error {
+	return out.withCOM(func() error {
+		out.lock.Lock()
+		defer out.lock.Unlock()
+		if out.closed || !out.paused || out.client == nil {
+			return nil
+		}
+		if err := out.client.Start(); err != nil {
+			return err
+		}
+		out.paused = false
+		out.cond.Signal()
+		return nil
+	})
+}
+
+func (out *wasapiOutput) Drop() error {
+	return out.withCOM(func() error {
+		out.lock.Lock()
+		defer out.lock.Unlock()
+		if out.closed || out.client == nil {
+			return nil
+		}
+
+		playing := !out.paused
+		if playing {
+			if err := out.client.Stop(); err != nil {
+				return err
+			}
+		}
+		if err := out.client.Reset(); err != nil {
+			return err
+		}
+		if playing {
+			if err := out.client.Start(); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (out *wasapiOutput) DelayMs() (int64, error) {
+	var delay int64
+	err := out.withCOM(func() error {
+		out.lock.Lock()
+		defer out.lock.Unlock()
+		if out.closed || out.paused || out.client == nil {
+			return nil
+		}
+		padding, err := out.client.GetCurrentPadding()
+		if err != nil {
+			return err
+		}
+		delay = int64(padding) * 1000 / int64(out.sampleRate)
+		return nil
+	})
+	return delay, err
+}
+
+func (out *wasapiOutput) SetVolume(vol float32) {
+	if vol < 0 || vol > 1 {
+		panic(fmt.Sprintf("invalid volume value: %0.2f", vol))
+	}
+	out.lock.Lock()
+	out.volume = vol
+	out.lock.Unlock()
+	if out.volumeUpdate != nil {
+		sendVolumeUpdate(out.volumeUpdate, vol)
+	}
+}
+
+func (out *wasapiOutput) Error() <-chan error {
+	return out.err
+}
+
+func (out *wasapiOutput) Close() error {
+	out.lock.Lock()
+	if out.closed {
+		out.lock.Unlock()
+		return nil
+	}
+	out.closed = true
+	if out.client != nil {
+		_ = out.client.Stop()
+	}
+	out.cond.Signal()
+	out.lock.Unlock()
+
+	<-out.done
+	if err := out.withCOM(func() error {
+		out.release()
+		return nil
+	}); err != nil {
+		out.release()
+	}
+	return nil
+}
+
+func (out *wasapiOutput) withCOM(fn func() error) error {
+	if err := coInitialize(); err != nil {
+		return fmt.Errorf("wasapi: CoInitializeEx: %w", err)
+	}
+	defer windows.CoUninitialize()
+	return fn()
+}
+
+func (out *wasapiOutput) release() {
+	if out.render != nil {
+		out.render.Release()
+		out.render = nil
+	}
+	if out.client != nil {
+		out.client.Release()
+		out.client = nil
+	}
+	if out.enumerator != nil {
+		out.enumerator.Release()
+		out.enumerator = nil
+	}
+	if out.ready != 0 {
+		_ = windows.CloseHandle(out.ready)
+		out.ready = 0
+	}
+}
+
+func coInitialize() error {
+	err := windows.CoInitializeEx(0, windows.COINIT_MULTITHREADED)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, syscall.Errno(windows.S_FALSE)) {
+		return nil
+	}
+	return err
+}

--- a/output/driver-wasapi_test.go
+++ b/output/driver-wasapi_test.go
@@ -1,0 +1,61 @@
+//go:build windows && test_unit
+
+package output
+
+import (
+	"strings"
+	"testing"
+)
+
+type silenceReader struct{}
+
+func (silenceReader) Read(p []float32) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func TestWasapiRequiresReader(t *testing.T) {
+	_, err := NewOutput(&NewOutputOptions{
+		Backend:      "wasapi",
+		SampleRate:   44100,
+		ChannelCount: 2,
+	})
+	if err == nil || !strings.Contains(err.Error(), "reader") {
+		t.Fatalf("error = %v, want reader required", err)
+	}
+}
+
+func TestWasapiDefaultDevice(t *testing.T) {
+	out, err := NewOutput(&NewOutputOptions{
+		Backend:      "wasapi",
+		Reader:       silenceReader{},
+		SampleRate:   44100,
+		ChannelCount: 2,
+		VolumeUpdate: make(chan float32, 1),
+	})
+	if err != nil {
+		t.Skipf("no usable default audio endpoint: %v", err)
+	}
+	defer func() { _ = out.Close() }()
+
+	if err := out.Pause(); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	if err := out.Drop(); err != nil {
+		t.Fatalf("Drop while paused: %v", err)
+	}
+	if delay, err := out.DelayMs(); err != nil {
+		t.Fatalf("DelayMs: %v", err)
+	} else if delay != 0 {
+		t.Fatalf("DelayMs while paused = %d, want 0", delay)
+	}
+	if err := out.Resume(); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if err := out.Drop(); err != nil {
+		t.Fatalf("Drop while playing: %v", err)
+	}
+	out.SetVolume(0.5)
+}

--- a/output/output.go
+++ b/output/output.go
@@ -59,6 +59,7 @@ type NewOutputOptions struct {
 	// Device specifies the audio device name.
 	//
 	// This feature is support only for the alsa and pulseaudio backend.
+	// The wasapi backend always uses the default playback endpoint.
 	Device string
 	// RuntimeSocket specifies a prefixed with protocol (e.g. `unix:` or `tcp:`) path
 	// to a runtime socket of audio backend.
@@ -87,8 +88,8 @@ type NewOutputOptions struct {
 
 	// InitialVolume specifies the initial output volume.
 	//
-	// This is only supported on the alsa backend. The PulseAudio backend uses
-	// the PulseAudio default volume.
+	// This is supported on the alsa, pipe, and wasapi backends. The PulseAudio
+	// backend uses the PulseAudio default volume.
 	InitialVolume float32
 
 	// ExternalVolume specifies, if the volume is controlled outside the app.
@@ -145,6 +146,12 @@ func NewOutput(options *NewOutputOptions) (Output, error) {
 		return out, nil
 	case "audio-toolbox":
 		out, err := newAudioToolboxOutput(options)
+		if err != nil {
+			return nil, err
+		}
+		return out, nil
+	case "wasapi":
+		out, err := newWasapiOutput(options)
 		if err != nil {
 			return nil, err
 		}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -1,0 +1,48 @@
+//go:build test_unit
+
+package output
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestWasapiBackendUnsupportedOffWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("wasapi is supported on Windows")
+	}
+	_, err := NewOutput(&NewOutputOptions{Backend: "wasapi"})
+	if err == nil {
+		t.Fatal("expected wasapi to be unsupported off Windows")
+	}
+	if !strings.Contains(err.Error(), "only supported on Windows") {
+		t.Fatalf("wasapi error = %q, want only supported on Windows", err)
+	}
+}
+
+func TestAlsaBackendUnsupportedOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("alsa is supported on this platform")
+	}
+	_, err := NewOutput(&NewOutputOptions{Backend: "alsa"})
+	if err == nil {
+		t.Fatal("expected alsa to be unsupported on Windows")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("alsa error = %q, want not supported", err)
+	}
+}
+
+func TestPipeBackendUnsupportedOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("pipe is supported on this platform")
+	}
+	_, err := NewOutput(&NewOutputOptions{Backend: "pipe"})
+	if err == nil {
+		t.Fatal("expected pipe to be unsupported on Windows")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("pipe error = %q, want not supported", err)
+	}
+}

--- a/output/wasapi_com_windows.go
+++ b/output/wasapi_com_windows.go
@@ -1,0 +1,350 @@
+//go:build windows
+
+package output
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// COM / WASAPI constants from mmdeviceapi.h, audioclient.h, and mmreg.h.
+const (
+	clsctxAll = 0x17 // CLSCTX_INPROC_SERVER|INPROC_HANDLER|LOCAL_SERVER|REMOTE_SERVER
+
+	eRender  = 0
+	eConsole = 0
+
+	audclntSharemodeShared = 0
+
+	audclntStreamflagsEventcallback  = 0x00040000
+	audclntStreamflagsNopersist      = 0x00080000
+	audclntStreamflagsSrcDefaultQual = 0x08000000
+	audclntStreamflagsAutoconvertPCM = 0x80000000
+
+	waveFormatTagExtensible = 0xFFFE
+	speakerFrontLeft        = 0x1
+	speakerFrontRight       = 0x2
+	speakerFrontCenter      = 0x4
+
+	audclntENotStopped        = 0x88890024
+	audclntEDeviceInvalidated = 0x88890004
+)
+
+// Interface IDs from the Windows SDK headers (mmdeviceapi.h, audioclient.h).
+var (
+	clsidMMDeviceEnumerator = windows.GUID{
+		Data1: 0xbcde0395, Data2: 0xe52f, Data3: 0x467c,
+		Data4: [8]byte{0x8e, 0x3d, 0xc4, 0x57, 0x92, 0x91, 0x69, 0x2e},
+	}
+	iidIMMDeviceEnumerator = windows.GUID{
+		Data1: 0xa95664d2, Data2: 0x9614, Data3: 0x4f35,
+		Data4: [8]byte{0xa7, 0x46, 0xde, 0x8d, 0xb6, 0x36, 0x17, 0xe6},
+	}
+	iidIAudioClient = windows.GUID{
+		Data1: 0x1cb9ad4c, Data2: 0xdbfa, Data3: 0x4c32,
+		Data4: [8]byte{0xb1, 0x78, 0xc2, 0xf5, 0x68, 0xa7, 0x03, 0xb2},
+	}
+	iidIAudioRenderClient = windows.GUID{
+		Data1: 0xf294acfc, Data2: 0x3146, Data3: 0x4483,
+		Data4: [8]byte{0xa7, 0xbf, 0xad, 0xdc, 0xa7, 0xc2, 0x60, 0xe2},
+	}
+	// KSDATAFORMAT_SUBTYPE_IEEE_FLOAT
+	ksDataFormatSubtypeIEEEFloat = windows.GUID{
+		Data1: 0x00000003, Data2: 0x0000, Data3: 0x0010,
+		Data4: [8]byte{0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71},
+	}
+)
+
+var (
+	modOle32             = windows.NewLazySystemDLL("ole32.dll")
+	procCoCreateInstance = modOle32.NewProc("CoCreateInstance")
+)
+
+type hresult uint32
+
+func (hr hresult) Error() string {
+	return fmt.Sprintf("wasapi HRESULT 0x%08x", uint32(hr))
+}
+
+func hrError(r uintptr) error {
+	if r == 0 || r == 1 { // S_OK, S_FALSE
+		return nil
+	}
+	return hresult(r)
+}
+
+func isHRESULT(err error, code uint32) bool {
+	hr, ok := err.(hresult)
+	return ok && uint32(hr) == code
+}
+
+// WAVEFORMATEXTENSIBLE as defined in mmreg.h.
+type waveFormatExtensible struct {
+	formatTag      uint16
+	channels       uint16
+	samplesPerSec  uint32
+	avgBytesPerSec uint32
+	blockAlign     uint16
+	bitsPerSample  uint16
+	cbSize         uint16
+	validBits      uint16
+	channelMask    uint32
+	subFormat      windows.GUID
+}
+
+func newFloatFormat(sampleRate, channels int) *waveFormatExtensible {
+	const bits = 32
+	block := channels * bits / 8
+	mask := uint32(speakerFrontCenter)
+	if channels == 2 {
+		mask = speakerFrontLeft | speakerFrontRight
+	}
+	return &waveFormatExtensible{
+		formatTag:      waveFormatTagExtensible,
+		channels:       uint16(channels),
+		samplesPerSec:  uint32(sampleRate),
+		avgBytesPerSec: uint32(sampleRate * block),
+		blockAlign:     uint16(block),
+		bitsPerSample:  bits,
+		cbSize:         22,
+		validBits:      bits,
+		channelMask:    mask,
+		subFormat:      ksDataFormatSubtypeIEEEFloat,
+	}
+}
+
+type iUnknownVtbl struct {
+	queryInterface uintptr
+	addRef         uintptr
+	release        uintptr
+}
+
+type immDeviceEnumeratorVtbl struct {
+	iUnknownVtbl
+	enumAudioEndpoints                     uintptr
+	getDefaultAudioEndpoint                uintptr
+	getDevice                              uintptr
+	registerEndpointNotificationCallback   uintptr
+	unregisterEndpointNotificationCallback uintptr
+}
+
+type immDeviceVtbl struct {
+	iUnknownVtbl
+	activate          uintptr
+	openPropertyStore uintptr
+	getId             uintptr
+	getState          uintptr
+}
+
+type iAudioClientVtbl struct {
+	iUnknownVtbl
+	initialize        uintptr
+	getBufferSize     uintptr
+	getStreamLatency  uintptr
+	getCurrentPadding uintptr
+	isFormatSupported uintptr
+	getMixFormat      uintptr
+	getDevicePeriod   uintptr
+	start             uintptr
+	stop              uintptr
+	reset             uintptr
+	setEventHandle    uintptr
+	getService        uintptr
+}
+
+type iAudioRenderClientVtbl struct {
+	iUnknownVtbl
+	getBuffer     uintptr
+	releaseBuffer uintptr
+}
+
+type immDeviceEnumerator struct{ vtbl *immDeviceEnumeratorVtbl }
+type immDevice struct{ vtbl *immDeviceVtbl }
+type iAudioClient struct{ vtbl *iAudioClientVtbl }
+type iAudioRenderClient struct{ vtbl *iAudioRenderClientVtbl }
+
+func comRelease(release uintptr, obj unsafe.Pointer) {
+	if obj == nil || release == 0 {
+		return
+	}
+	_, _, _ = syscallN(release, uintptr(obj))
+}
+
+func syscallN(trap uintptr, args ...uintptr) (uintptr, uintptr, error) {
+	return syscall.SyscallN(trap, args...)
+}
+
+// Thin wrappers so the driver never touches vtable slots directly.
+
+func coCreateMMDeviceEnumerator() (*immDeviceEnumerator, error) {
+	var unk unsafe.Pointer
+	r, _, _ := procCoCreateInstance.Call(
+		uintptr(unsafe.Pointer(&clsidMMDeviceEnumerator)),
+		0,
+		clsctxAll,
+		uintptr(unsafe.Pointer(&iidIMMDeviceEnumerator)),
+		uintptr(unsafe.Pointer(&unk)),
+	)
+	if err := hrError(r); err != nil {
+		return nil, fmt.Errorf("CoCreateInstance(MMDeviceEnumerator): %w", err)
+	}
+	return (*immDeviceEnumerator)(unk), nil
+}
+
+func (e *immDeviceEnumerator) GetDefaultAudioEndpoint() (*immDevice, error) {
+	var dev *immDevice
+	r, _, _ := syscallN(e.vtbl.getDefaultAudioEndpoint,
+		uintptr(unsafe.Pointer(e)),
+		eRender,
+		eConsole,
+		uintptr(unsafe.Pointer(&dev)),
+	)
+	if err := hrError(r); err != nil {
+		return nil, fmt.Errorf("IMMDeviceEnumerator.GetDefaultAudioEndpoint: %w", err)
+	}
+	return dev, nil
+}
+
+func (e *immDeviceEnumerator) Release() {
+	if e != nil {
+		comRelease(e.vtbl.release, unsafe.Pointer(e))
+	}
+}
+
+func (d *immDevice) ActivateAudioClient() (*iAudioClient, error) {
+	var client *iAudioClient
+	r, _, _ := syscallN(d.vtbl.activate,
+		uintptr(unsafe.Pointer(d)),
+		uintptr(unsafe.Pointer(&iidIAudioClient)),
+		clsctxAll,
+		0,
+		uintptr(unsafe.Pointer(&client)),
+	)
+	if err := hrError(r); err != nil {
+		return nil, fmt.Errorf("IMMDevice.Activate(IAudioClient): %w", err)
+	}
+	return client, nil
+}
+
+func (d *immDevice) Release() {
+	if d != nil {
+		comRelease(d.vtbl.release, unsafe.Pointer(d))
+	}
+}
+
+func (c *iAudioClient) Initialize(bufferDuration100ns int64, format *waveFormatExtensible) error {
+	flags := uintptr(audclntStreamflagsEventcallback | audclntStreamflagsNopersist |
+		audclntStreamflagsAutoconvertPCM | audclntStreamflagsSrcDefaultQual)
+	r, _, _ := syscallN(c.vtbl.initialize,
+		uintptr(unsafe.Pointer(c)),
+		audclntSharemodeShared,
+		flags,
+		uintptr(bufferDuration100ns),
+		0,
+		uintptr(unsafe.Pointer(format)),
+		0,
+	)
+	if err := hrError(r); err != nil {
+		return fmt.Errorf("IAudioClient.Initialize: %w", err)
+	}
+	return nil
+}
+
+func (c *iAudioClient) GetBufferSize() (uint32, error) {
+	var frames uint32
+	r, _, _ := syscallN(c.vtbl.getBufferSize, uintptr(unsafe.Pointer(c)), uintptr(unsafe.Pointer(&frames)))
+	if err := hrError(r); err != nil {
+		return 0, fmt.Errorf("IAudioClient.GetBufferSize: %w", err)
+	}
+	return frames, nil
+}
+
+func (c *iAudioClient) GetCurrentPadding() (uint32, error) {
+	var frames uint32
+	r, _, _ := syscallN(c.vtbl.getCurrentPadding, uintptr(unsafe.Pointer(c)), uintptr(unsafe.Pointer(&frames)))
+	if err := hrError(r); err != nil {
+		return 0, fmt.Errorf("IAudioClient.GetCurrentPadding: %w", err)
+	}
+	return frames, nil
+}
+
+func (c *iAudioClient) Start() error {
+	r, _, _ := syscallN(c.vtbl.start, uintptr(unsafe.Pointer(c)))
+	if err := hrError(r); err != nil && !isHRESULT(err, audclntENotStopped) {
+		return fmt.Errorf("IAudioClient.Start: %w", err)
+	}
+	return nil
+}
+
+func (c *iAudioClient) Stop() error {
+	r, _, _ := syscallN(c.vtbl.stop, uintptr(unsafe.Pointer(c)))
+	if err := hrError(r); err != nil {
+		return fmt.Errorf("IAudioClient.Stop: %w", err)
+	}
+	return nil
+}
+
+func (c *iAudioClient) Reset() error {
+	r, _, _ := syscallN(c.vtbl.reset, uintptr(unsafe.Pointer(c)))
+	if err := hrError(r); err != nil {
+		return fmt.Errorf("IAudioClient.Reset: %w", err)
+	}
+	return nil
+}
+
+func (c *iAudioClient) SetEventHandle(ev windows.Handle) error {
+	r, _, _ := syscallN(c.vtbl.setEventHandle, uintptr(unsafe.Pointer(c)), uintptr(ev))
+	if err := hrError(r); err != nil {
+		return fmt.Errorf("IAudioClient.SetEventHandle: %w", err)
+	}
+	return nil
+}
+
+func (c *iAudioClient) GetRenderClient() (*iAudioRenderClient, error) {
+	var rc *iAudioRenderClient
+	r, _, _ := syscallN(c.vtbl.getService,
+		uintptr(unsafe.Pointer(c)),
+		uintptr(unsafe.Pointer(&iidIAudioRenderClient)),
+		uintptr(unsafe.Pointer(&rc)),
+	)
+	if err := hrError(r); err != nil {
+		return nil, fmt.Errorf("IAudioClient.GetService(IAudioRenderClient): %w", err)
+	}
+	return rc, nil
+}
+
+func (c *iAudioClient) Release() {
+	if c != nil {
+		comRelease(c.vtbl.release, unsafe.Pointer(c))
+	}
+}
+
+func (r *iAudioRenderClient) GetBuffer(frames uint32) (*byte, error) {
+	var buf *byte
+	hr, _, _ := syscallN(r.vtbl.getBuffer,
+		uintptr(unsafe.Pointer(r)),
+		uintptr(frames),
+		uintptr(unsafe.Pointer(&buf)),
+	)
+	if err := hrError(hr); err != nil {
+		return nil, fmt.Errorf("IAudioRenderClient.GetBuffer: %w", err)
+	}
+	return buf, nil
+}
+
+func (r *iAudioRenderClient) ReleaseBuffer(frames uint32) error {
+	hr, _, _ := syscallN(r.vtbl.releaseBuffer, uintptr(unsafe.Pointer(r)), uintptr(frames), 0)
+	if err := hrError(hr); err != nil {
+		return fmt.Errorf("IAudioRenderClient.ReleaseBuffer: %w", err)
+	}
+	return nil
+}
+
+func (r *iAudioRenderClient) Release() {
+	if r != nil {
+		comRelease(r.vtbl.release, unsafe.Pointer(r))
+	}
+}

--- a/vcpkg-triplets/x64-mingw-static.cmake
+++ b/vcpkg-triplets/x64-mingw-static.cmake
@@ -1,0 +1,11 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_ENV_PASSTHROUGH PATH)
+set(VCPKG_CMAKE_SYSTEM_NAME MinGW)
+set(VCPKG_BUILD_TYPE release)
+
+# Match the Linux triplets: C decoder only. The C++ FLAC API is unused.
+if(PORT STREQUAL "libflac")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS -DBUILD_CXXLIBS=OFF)
+endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,9 @@
 {
   "dependencies": [
-    "alsa",
+    {
+      "name": "alsa",
+      "platform": "linux"
+    },
     "libvorbis",
     "libflac",
     "mpg123"


### PR DESCRIPTION
# Windows build notes

This is a working log of what it took to compile go-librespot on Windows, build the native decode libraries, and get Spotify Connect playback through WASAPI. Tested on Windows 11 (`windows/amd64`) against `feat/windows-compile`.

## Result

- The daemon compiles as a single `go-librespot.exe`.
- Default `audio_backend` is `wasapi` (default Windows playback device, software volume).
- Zeroconf discovery, Login5, Vorbis decode, pause/skip, and headset output all worked in a live Premium session.
- There is no `go-wca` dependency. WASAPI is first-party COM via `golang.org/x/sys/windows`, same idea as the in-tree ALSA and Audio Toolbox drivers.

## What changed in the tree

| Area | Change |
|---|---|
| Output | ALSA stub covers Windows. Pipe open is Unix-only. New `wasapi` backend. |
| Config | Windows default backend is `wasapi`. Schema/README list the new name. |
| vcpkg | `alsa` is Linux-only. Overlay triplet `vcpkg-triplets/x64-mingw-static.cmake`. |
| State | `state.json` is closed before rename; Windows can replace an existing file. |
| Cache tests | Readers are closed so `TempDir` cleanup does not fail on Windows. |
| CI | `windows-2022` MSYS2 build/test + Ubuntu MinGW/vcpkg cross-compile. Release uploads `go-librespot_windows_amd64.tar.gz`. |

## Native libraries

CGO still needs **libogg**, **libvorbis**, **libflac**, and **mpg123**. ALSA is not used on Windows.

Those must be **MinGW** static libraries. MSVC/`x64-windows` `.lib` files will not link with Go CGO.

### vcpkg (matches this repo)

Needs `x86_64-w64-mingw32-gcc` on `PATH` (WinLibs or MSYS2). Put the tools on an **ASCII path** if the Windows user name has non-ASCII characters; Ninja/CMake can fail on those paths.

```powershell
$env:VCPKG_ROOT = "C:\path\to\vcpkg"
$env:PATH = "C:\path\to\mingw64\bin;$env:PATH"

vcpkg install --triplet x64-mingw-static
```

That installs into `vcpkg_installed/x64-mingw-static/` (gitignored). `libogg` comes in as a dependency of vorbis/flac.

### MSYS2 (what GitHub Actions uses)

```
pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config `
  mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis `
  mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123
```

## Building the daemon

```powershell
$env:CGO_ENABLED = "1"
$env:CC = "x86_64-w64-mingw32-gcc"
$env:PKG_CONFIG_PATH = "$PWD\vcpkg_installed\x64-mingw-static\lib\pkgconfig"
$env:CGO_LDFLAGS = "-static"   # avoid shipping libssp-0.dll

go build -o go-librespot.exe -ldflags "-s -w" ./cmd/daemon
```

With MSYS2 packages, omit `PKG_CONFIG_PATH` if `pkg-config` already finds `flac`, `libmpg123`, `ogg`, `vorbis`, and `vorbisenc`.

`-static` links libssp from FLAC's stack-protector. The exe then only imports Windows system DLLs (`KERNEL32`, UCRT, `ADVAPI32`, `SHLWAPI`).

## Running / testing

```powershell
.\go-librespot.exe -c log_level=debug
```

Config lives in `%APPDATA%\go-librespot`. Default credentials are zeroconf (Spotify Premium, same LAN).

Healthy log lines:

- `zeroconf server listening on port …`
- `using built-in mDNS responder`
- `authenticated AP` / `accepted zeroconf`
- `started wasapi output`
- `loaded track …`

Then transfer playback in the official Spotify app. Allow the exe through Windows Firewall on a private network if the device does not appear.

## Decisions worth knowing

1. **No `go-wca`.** Unmaintained; the owner's WASAPI fixes were never merged. Bindings live in `output/wasapi_com_windows.go` (Win32 vtable layouts).
2. **Do not copy oto source** into this GPL-3.0 tree without Apache-2.0 notices. We wrote the driver against the Windows SDK and this project's own `#4` sketch.
3. **v1 WASAPI** is default device + software volume only. Device picker, default-device hotplug, session volume, and SMTC are follow-ups.
4. **64-bit only.** `IAudioClient.Initialize` is wired for `windows/amd64`.

## CI artifacts (after the PR is open)

- **Build and Test** → `go-librespot-windows-amd64` (native MSYS2 exe)
- **Build and Test** → `go-librespot-windows-amd64-vcpkg` (Ubuntu cross-compile)
- **Release** → `go-librespot_windows_amd64.tar.gz` (also published on tags)