### PR TITLE
add option to wait for a FIFO reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ audio_buffer_time: 500000 # Audio buffer time in microseconds, ALSA only
 audio_period_count: 4 # Number of periods to request, ALSA only
 audio_output_pipe: '' # Path to a named pipe for audio output
 audio_output_pipe_format: s16le # Audio output pipe format (s16le, s32le, f32le)
+audio_output_pipe_wait_for_reader: false # Whether to wait for a reader to connect to the FIFO before starting playback (see below)
 bitrate: 160 # Playback bitrate (96, 160, 320)
 crossfade_duration: 0 # Crossfade duration between tracks in milliseconds (0 to disable)
 volume_steps: 100 # Volume steps count
@@ -266,6 +267,11 @@ If your network only allows outbound HTTP and HTTPS, set
 4070, 443 and 80 and normally lists 4070 first, which restrictive firewalls
 tend to block; enabling this tries 443 first, then 80, and falls back to 4070.
 The dealer and spclient are unaffected, as they already use 443.
+
+With the pipe backend, opening the FIFO fails if no reader is connected when
+playback starts. Some readers (e.g. snapcast with `dryout_ms`) only connect to
+the FIFO when they expect data. Set `audio_output_pipe_wait_for_reader: true`
+to instead wait for a reader to appear before starting playback.
 
 Make sure to check [here](/config_schema.json) for the full list of options.
 

--- a/cmd/daemon/cli_config.go
+++ b/cmd/daemon/cli_config.go
@@ -35,15 +35,16 @@ type cliConfig struct {
 	DeviceType  string `koanf:"device_type"`
 	ClientToken string `koanf:"client_token"`
 
-	AudioBackend              string `koanf:"audio_backend"`
-	AudioBackendRuntimeSocket string `koanf:"audio_backend_runtime_socket"`
-	AudioDevice               string `koanf:"audio_device"`
-	MixerDevice               string `koanf:"mixer_device"`
-	MixerControlName          string `koanf:"mixer_control_name"`
-	AudioBufferTime           int    `koanf:"audio_buffer_time"`
-	AudioPeriodCount          int    `koanf:"audio_period_count"`
-	AudioOutputPipe           string `koanf:"audio_output_pipe"`
-	AudioOutputPipeFormat     string `koanf:"audio_output_pipe_format"`
+	AudioBackend                 string `koanf:"audio_backend"`
+	AudioBackendRuntimeSocket    string `koanf:"audio_backend_runtime_socket"`
+	AudioDevice                  string `koanf:"audio_device"`
+	MixerDevice                  string `koanf:"mixer_device"`
+	MixerControlName             string `koanf:"mixer_control_name"`
+	AudioBufferTime              int    `koanf:"audio_buffer_time"`
+	AudioPeriodCount             int    `koanf:"audio_period_count"`
+	AudioOutputPipe              string `koanf:"audio_output_pipe"`
+	AudioOutputPipeFormat        string `koanf:"audio_output_pipe_format"`
+	AudioOutputPipeWaitForReader bool   `koanf:"audio_output_pipe_wait_for_reader"`
 
 	Bitrate                       int      `koanf:"bitrate"`
 	VolumeSteps                   uint32   `koanf:"volume_steps"`
@@ -102,15 +103,16 @@ func (c *cliConfig) toDaemonConfig() *daemon.Config {
 		DeviceType:  c.DeviceType,
 		ClientToken: c.ClientToken,
 
-		AudioBackend:              c.AudioBackend,
-		AudioBackendRuntimeSocket: c.AudioBackendRuntimeSocket,
-		AudioDevice:               c.AudioDevice,
-		MixerDevice:               c.MixerDevice,
-		MixerControlName:          c.MixerControlName,
-		AudioBufferTime:           c.AudioBufferTime,
-		AudioPeriodCount:          c.AudioPeriodCount,
-		AudioOutputPipe:           c.AudioOutputPipe,
-		AudioOutputPipeFormat:     c.AudioOutputPipeFormat,
+		AudioBackend:                 c.AudioBackend,
+		AudioBackendRuntimeSocket:    c.AudioBackendRuntimeSocket,
+		AudioDevice:                  c.AudioDevice,
+		MixerDevice:                  c.MixerDevice,
+		MixerControlName:             c.MixerControlName,
+		AudioBufferTime:              c.AudioBufferTime,
+		AudioPeriodCount:             c.AudioPeriodCount,
+		AudioOutputPipe:              c.AudioOutputPipe,
+		AudioOutputPipeFormat:        c.AudioOutputPipeFormat,
+		AudioOutputPipeWaitForReader: c.AudioOutputPipeWaitForReader,
 
 		Bitrate:                   c.Bitrate,
 		VolumeSteps:               c.VolumeSteps,

--- a/cmd/daemon/cli_config_test.go
+++ b/cmd/daemon/cli_config_test.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,4 +43,19 @@ func TestParseSize(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestLoadCLIConfigWaitForReaderFlag(t *testing.T) {
+	dir := t.TempDir()
+
+	config := []byte("audio_backend: pipe\naudio_output_pipe: /tmp/fifo/go-spotify\naudio_output_pipe_wait_for_reader: true\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), config, 0o600))
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"test", "--config_dir", dir}
+
+	cfg := &cliConfig{}
+	require.NoError(t, loadCLIConfig(cfg))
+	require.True(t, cfg.AudioOutputPipeWaitForReader, "audio_output_pipe_wait_for_reader was not parsed from the config file")
 }

--- a/config_schema.json
+++ b/config_schema.json
@@ -120,6 +120,11 @@
           ],
           "default": "s16le"
         },
+        "audio_output_pipe_wait_for_reader": {
+          "type": "boolean",
+          "description": "Whether to wait for a reader to connect to the FIFO before starting playback, instead of failing if none is present. Useful for readers (e.g. snapcast with dryout) that only connect when data is expected",
+          "default": false
+        },
         "server": {
           "type": "object",
           "properties": {

--- a/daemon/app.go
+++ b/daemon/app.go
@@ -278,8 +278,9 @@ func (app *App) newAppPlayer(ctx context.Context, creds any) (_ *AppPlayer, err 
 		ExternalVolume: app.cfg.ExternalVolume,
 		VolumeUpdate:   appPlayer.volumeUpdate,
 
-		AudioOutputPipe:       app.cfg.AudioOutputPipe,
-		AudioOutputPipeFormat: app.cfg.AudioOutputPipeFormat,
+		AudioOutputPipe:              app.cfg.AudioOutputPipe,
+		AudioOutputPipeFormat:        app.cfg.AudioOutputPipeFormat,
+		AudioOutputPipeWaitForReader: app.cfg.AudioOutputPipeWaitForReader,
 	},
 	); err != nil {
 		return nil, fmt.Errorf("failed initializing player: %w", err)

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -7,15 +7,16 @@ type Config struct {
 	DeviceType  string
 	ClientToken string
 
-	AudioBackend              string
-	AudioBackendRuntimeSocket string
-	AudioDevice               string
-	MixerDevice               string
-	MixerControlName          string
-	AudioBufferTime           int
-	AudioPeriodCount          int
-	AudioOutputPipe           string
-	AudioOutputPipeFormat     string
+	AudioBackend                 string
+	AudioBackendRuntimeSocket    string
+	AudioDevice                  string
+	MixerDevice                  string
+	MixerControlName             string
+	AudioBufferTime              int
+	AudioPeriodCount             int
+	AudioOutputPipe              string
+	AudioOutputPipeFormat        string
+	AudioOutputPipeWaitForReader bool
 
 	Bitrate                   int
 	VolumeSteps               uint32

--- a/output/driver-pipe.go
+++ b/output/driver-pipe.go
@@ -93,15 +93,25 @@ func newPipeOutput(opts *NewOutputOptions) (out *pipeOutput, err error) {
 		return nil, err
 	}
 
-	// Open the FIFO for writing as non-blocking to cause an error if there is no reader.
-	out.file, err = os.OpenFile(opts.OutputPipe, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+	// Open the FIFO for writing. When not waiting for a reader, open it as
+	// non-blocking to cause an error if there is no reader. When waiting for a
+	// reader (e.g. snapcast with dryout), the blocking open will wait until a
+	// reader connects.
+	flags := os.O_WRONLY
+	if !opts.OutputPipeWaitForReader {
+		flags |= syscall.O_NONBLOCK
+	}
+
+	out.file, err = os.OpenFile(opts.OutputPipe, flags, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open fifo: %w", err)
 	}
 
-	// Restore blocking mode now that we are sure we have a reader.
-	if err := syscall.SetNonblock(int(out.file.Fd()), false); err != nil {
-		return nil, fmt.Errorf("failed to set blocking mode on fifo: %w", err)
+	if !opts.OutputPipeWaitForReader {
+		// Restore blocking mode now that we are sure we have a reader.
+		if err := syscall.SetNonblock(int(out.file.Fd()), false); err != nil {
+			return nil, fmt.Errorf("failed to set blocking mode on fifo: %w", err)
+		}
 	}
 
 	go out.outputLoop()

--- a/output/driver-pipe_test.go
+++ b/output/driver-pipe_test.go
@@ -4,8 +4,13 @@ package output
 
 import (
 	"encoding/binary"
+	"io"
 	"math"
+	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func s16(t *testing.T, in []float32) []int16 {
@@ -140,4 +145,82 @@ func TestPipeTransformUnknownFormat(t *testing.T) {
 	if _, err := newPipeTransform("s24le"); err == nil {
 		t.Fatal("expected an error for an unsupported format")
 	}
+}
+
+// eofReader is a Float32Reader that reports end of stream, so the pipe output
+// loop goes idle and blocks on the cond var instead of writing.
+type eofReader struct{}
+
+func (eofReader) Read([]float32) (int, error) {
+	return 0, io.EOF
+}
+
+func mkfifo(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test-fifo")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	return path
+}
+
+func pipeOutputOptions(path string, waitForReader bool) *NewOutputOptions {
+	return &NewOutputOptions{
+		Reader:                  eofReader{},
+		OutputPipe:              path,
+		OutputPipeFormat:        "s16le",
+		OutputPipeWaitForReader: waitForReader,
+	}
+}
+
+func TestPipeOutputFailsWithoutReader(t *testing.T) {
+	out, err := newPipeOutput(pipeOutputOptions(mkfifo(t), false))
+	if err == nil {
+		out.Close()
+		t.Fatal("expected an error opening the FIFO without a reader")
+	}
+}
+
+func TestPipeOutputWaitsForReader(t *testing.T) {
+	path := mkfifo(t)
+
+	result := make(chan *pipeOutput, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		out, err := newPipeOutput(pipeOutputOptions(path, true))
+		if err != nil {
+			errCh <- err
+			return
+		}
+		result <- out
+	}()
+
+	// The open must wait for a reader instead of failing.
+	select {
+	case out := <-result:
+		out.Close()
+		t.Fatal("expected newPipeOutput to wait for a reader")
+	case err := <-errCh:
+		t.Fatalf("newPipeOutput returned error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Connect a reader: the pending open should now complete.
+	reader, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("failed opening FIFO for reading: %v", err)
+	}
+	defer reader.Close()
+
+	var out *pipeOutput
+	select {
+	case out = <-result:
+	case err := <-errCh:
+		t.Fatalf("newPipeOutput returned error: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for newPipeOutput to open the FIFO")
+	}
+
+	defer out.Close()
 }

--- a/output/output.go
+++ b/output/output.go
@@ -113,6 +113,14 @@ type NewOutputOptions struct {
 	//
 	// This is only supported on the pipe backend.
 	OutputPipeFormat string
+
+	// OutputPipeWaitForReader makes the pipe backend wait for a reader to
+	// appear when opening the FIFO, instead of failing if none is present at the
+	// time playback starts. This is useful for readers (e.g. snapcast with
+	// dryout) that only connect to the FIFO when data is expected.
+	//
+	// This is only supported on the pipe backend.
+	OutputPipeWaitForReader bool
 }
 
 func NewOutput(options *NewOutputOptions) (Output, error) {

--- a/player/player.go
+++ b/player/player.go
@@ -183,6 +183,14 @@ type Options struct {
 	//
 	// This is only supported on the pipe backend.
 	AudioOutputPipeFormat string
+
+	// AudioOutputPipeWaitForReader makes the pipe backend wait for a reader to
+	// appear when opening the FIFO, instead of failing if none is present at the
+	// time playback starts. This is useful for readers (e.g. snapcast with
+	// dryout) that only connect to the FIFO when data is expected.
+	//
+	// This is only supported on the pipe backend.
+	AudioOutputPipeWaitForReader bool
 }
 
 func NewPlayer(opts *Options) (*Player, error) {
@@ -202,22 +210,23 @@ func NewPlayer(opts *Options) (*Player, error) {
 		defaultAudioDevice:        opts.AudioDevice,
 		newOutput: func(reader librespot.Float32Reader, volume float32, device string) (output.Output, error) {
 			return output.NewOutput(&output.NewOutputOptions{
-				Log:              opts.Log,
-				Backend:          opts.AudioBackend,
-				Reader:           reader,
-				SampleRate:       SampleRate,
-				ChannelCount:     Channels,
-				Device:           device,
-				RuntimeSocket:    opts.AudioBackendRuntimeSocket,
-				Mixer:            opts.MixerDevice,
-				Control:          opts.MixerControlName,
-				InitialVolume:    volume,
-				BufferTimeMicro:  opts.AudioBufferTime,
-				PeriodCount:      opts.AudioPeriodCount,
-				ExternalVolume:   opts.ExternalVolume,
-				VolumeUpdate:     opts.VolumeUpdate,
-				OutputPipe:       opts.AudioOutputPipe,
-				OutputPipeFormat: opts.AudioOutputPipeFormat,
+				Log:                     opts.Log,
+				Backend:                 opts.AudioBackend,
+				Reader:                  reader,
+				SampleRate:              SampleRate,
+				ChannelCount:            Channels,
+				Device:                  device,
+				RuntimeSocket:           opts.AudioBackendRuntimeSocket,
+				Mixer:                   opts.MixerDevice,
+				Control:                 opts.MixerControlName,
+				InitialVolume:           volume,
+				BufferTimeMicro:         opts.AudioBufferTime,
+				PeriodCount:             opts.AudioPeriodCount,
+				ExternalVolume:          opts.ExternalVolume,
+				VolumeUpdate:            opts.VolumeUpdate,
+				OutputPipe:              opts.AudioOutputPipe,
+				OutputPipeFormat:        opts.AudioOutputPipeFormat,
+				OutputPipeWaitForReader: opts.AudioOutputPipeWaitForReader,
 			})
 		},
 


### PR DESCRIPTION
 ## What

 Fixes #294: with the pipe backend, playback fails at stream setup with
 `failed to open fifo: ... no such device or address` when no reader is
 connected to the FIFO at the time playback starts (e.g. snapcast with
 `dryout_ms`, which only connects to the FIFO when it expects data).

 This regression was introduced by the fail-fast FIFO open from #285
 (#284).

 ## Change

 The pipe backend keeps failing fast by default, but a new config option
 lets users opt into waiting for a reader:

 ```yaml
 audio_output_pipe_wait_for_reader: true

 When enabled, the FIFO is opened with a blocking open() (matching the
 pre-0.7.0 behavior) and playback waits until a reader connects, instead
 of aborting.

 Testing

 - TestPipeOutputFailsWithoutReader: default fail-fast behavior is preserved
 - TestPipeOutputWaitsForReader: with the option enabled, the open waits for
   a reader and completes once one connects
 - TestLoadCLIConfigWaitForReaderFlag: the new config key is parsed correctly
 - go build ./... and full test_unit test_integration suite pass