### PR TITLE
Fix/audio correctness

### DIFF
--- a/audio/decryptor.go
+++ b/audio/decryptor.go
@@ -14,7 +14,6 @@ type Decryptor struct {
 }
 
 var baseIv = []byte{0x72, 0xe0, 0x67, 0xfb, 0xdd, 0xcb, 0xcf, 0x77, 0xeb, 0xe8, 0xbc, 0x64, 0x3f, 0x63, 0x0d, 0x93}
-var throwawayBuffer = make([]byte, aes.BlockSize)
 
 func NewAesAudioDecryptor(r io.ReaderAt, key []byte) (*Decryptor, error) {
 	c, err := aes.NewCipher(key)
@@ -42,7 +41,8 @@ func (a *Decryptor) ReadAt(p []byte, pos int64) (n int, err error) {
 
 	// read some bytes to throw away
 	if off > 0 {
-		stream.XORKeyStream(throwawayBuffer, throwawayBuffer[:off])
+		var throwawayBuffer [aes.BlockSize]byte
+		stream.XORKeyStream(throwawayBuffer[:], throwawayBuffer[:off])
 	}
 
 	// read from source and decrypt

--- a/audio/provider.go
+++ b/audio/provider.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -82,7 +83,10 @@ func (p *KeyProvider) recvLoop() {
 			switch pkt.Type {
 			case ap.PacketTypeAesKey:
 				key := make([]byte, 16)
-				_, _ = resp.Read(key)
+				if _, err := io.ReadFull(resp, key); err != nil {
+					req.resp <- keyResponse{err: fmt.Errorf("malformed aes key response for sequence %d: %w", respSeq, err)}
+					continue
+				}
 				req.resp <- keyResponse{key: key}
 			case ap.PacketTypeAesKeyError:
 				var errCode uint16

--- a/vorbis/decoder.go
+++ b/vorbis/decoder.go
@@ -374,6 +374,15 @@ func (d *Decoder) SetPositionMs(pos int64) (err error) {
 
 	// we trust that the bytes offset we were given is accurate and process the data at this point
 	if _, err = d.readChunk(); err != nil {
+		if errors.Is(err, io.EOF) {
+			// The seek table only estimates a byte offset, and its
+			// resolution is coarsest right at the tail of the track, so
+			// landing on or past the last page here is an expected outcome
+			// of seeking close to the end, not a failure. Leave the decoder
+			// positioned at EOF; the next Read will correctly report the
+			// track as finished.
+			return nil
+		}
 		return fmt.Errorf("failed reading chunk: %w", err)
 	}
 
@@ -382,6 +391,11 @@ func (d *Decoder) SetPositionMs(pos int64) (err error) {
 
 	// read the page now that we are aligned
 	if err = d.readNextPage(); err != nil {
+		if errors.Is(err, io.EOF) {
+			// see comment above: landing on the EOS page while seeking is
+			// a valid outcome, not a failure
+			return nil
+		}
 		return fmt.Errorf("failed reading page: %w", err)
 	}
 


### PR DESCRIPTION
Three small, independent fixes I hit while working on playback reliability. Each is its own
commit; happy to split into separate PRs if you'd rather review them that way.

## `audio/provider.go` — reject truncated audio key packets instead of using them

The AES key response was read into a fixed 16-byte buffer without checking how many bytes
actually came back:

```go
key := make([]byte, 16)
_, _ = resp.Read(key)
```

`Read` is not guaranteed to fill the buffer in one call, and the return value was discarded, so a
short/truncated packet was silently accepted as a valid key — just zero-padded in whatever bytes
didn't arrive. Decrypting with a wrong key produces garbage from byte 0, which then surfaces far
downstream as a confusing decoder error instead of a clear key-fetch failure at the source.

Fixed with `io.ReadFull`, returning a descriptive error (including the sequence number) instead
of continuing with a bad key.

## `audio/decryptor.go` — avoid data race on shared decryption scratch buffer

```go
var throwawayBuffer = make([]byte, aes.BlockSize)
```

was a single package-level slice, shared by every `Decryptor.ReadAt` call across every goroutine
— including concurrent primary and prefetch streams, which is a normal state for this daemon.
Two goroutines calling `XORKeyStream` on the same backing array concurrently is a straightforward
data race (confirmed with `-race`). Made it a local, stack-allocated `[aes.BlockSize]byte` per
call instead — no shared state, no behavior change.

## `vorbis/decoder.go` — treat EOF while seeking near track end as success

`SetPositionMs` seeks to a byte offset estimated from a coarse seek table. That table's
resolution is worst right at the tail of a track, so an estimate landing on or past the last Ogg
page was common when seeking close to the end — and was treated as a hard failure, aborting the
whole track load. Landing at/near the end is a valid, if imprecise, outcome of a seek, not an
error. This reliably broke Spotify Connect "transfer" when resuming a track reasonably close to
its end (a common case — e.g. transferring playback shortly before a track finishes).

Both `readChunk()` and `readNextPage()` call sites in `SetPositionMs` now treat `io.EOF`
specifically as "seek landed at the end, decoder is correctly positioned at EOF" rather than
propagating it as an error.
