### PR TITLE
fix: dealer-raw-command

### DIFF
--- a/daemon/player.go
+++ b/daemon/player.go
@@ -418,6 +418,7 @@ func (p *AppPlayer) handlePlayerCommand(ctx context.Context, req dealer.RequestP
 		p.addToQueue(ctx, req.Command.Track)
 		return nil
 	default:
+		p.app.log.Warnf("unsupported player command %q payload: %s", req.Command.Endpoint, req.RawCommand)
 		return fmt.Errorf("unsupported player command: %s", req.Command.Endpoint)
 	}
 }

--- a/dealer/recv.go
+++ b/dealer/recv.go
@@ -93,6 +93,13 @@ type RequestPayload struct {
 		} `json:"play_options"`
 		FromDeviceIdentifier string `json:"from_device_identifier"`
 	} `json:"command"`
+
+	// RawCommand holds the command object's raw JSON, populated separately
+	// from Command above (see handleRequest). Command only exposes the
+	// fields we've modeled; a payload field we haven't added yet silently
+	// disappears on unmarshal otherwise, which makes an unhandled command's
+	// actual shape impossible to inspect from Command alone.
+	RawCommand json.RawMessage `json:"-"`
 }
 
 func handleTransferEncoding(headers map[string]string, data []byte) ([]byte, error) {
@@ -231,6 +238,14 @@ func (d *Dealer) handleRequest(rawMsg *RawMessage) {
 		log.WithError(err).Error("failed unmarshalling dealer request payload")
 		return
 	}
+
+	// keep the command's raw JSON around too, so a command we don't model
+	// yet can still be inspected in full (see RawCommand)
+	var rawEnvelope struct {
+		Command json.RawMessage `json:"command"`
+	}
+	_ = json.Unmarshal(payloadBytes, &rawEnvelope)
+	payload.RawCommand = rawEnvelope.Command
 
 	// dispatch request
 	resp := make(chan bool, 1)


### PR DESCRIPTION
RequestPayload.Command only exposes the fields I've modeled, and encoding/json silently drops everything else on unmarshal, so a command we don't handle yet arrives as an all-empty struct with no way to see what Spotify actually sent - the field names have to be guessed before support for it can be written.

Keeps the command object's raw JSON alongside the parsed struct, and logs it when an unsupported player command comes in.