### PR TITLE
session: Add the device authorization flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,24 @@ requires some manual steps to complete the authentication:
    curl http://127.0.0.1:36842/login?code=xxxxxxxx
    ```
 
+### Device authorization mode
+
+This mode associates your account with the device without a browser on the device itself: Spotify issues a short code
+which you enter at [spotify.com/pair](https://spotify.com/pair) from a phone or computer. Nothing has to listen on a
+port, so unlike interactive mode there is no redirect URL to copy around when go-librespot runs headless.
+
+1. Configure device authorization mode
+
+    ```yaml
+    zeroconf_enabled: false # Whether to keep the device discoverable at all times
+    credentials:
+      type: device_auth
+    ```
+
+2. Start the daemon to begin the authentication flow
+3. Open the link it logs, or go to [spotify.com/pair](https://spotify.com/pair) and enter the code it prints
+4. Approve the request; the daemon picks it up automatically and stores the credentials
+
 ### API server
 
 Optionally, an API server can be started to control and monitor the player. To enable this feature, add the following to

--- a/ap/ap.go
+++ b/ap/ap.go
@@ -124,11 +124,17 @@ func (ap *Accesspoint) init(ctx context.Context) (err error) {
 }
 
 func (ap *Accesspoint) ConnectSpotifyToken(ctx context.Context, username, token string) error {
-	return ap.Connect(ctx, &pb.LoginCredentials{
+	creds := &pb.LoginCredentials{
 		Typ:      pb.AuthenticationType_AUTHENTICATION_SPOTIFY_TOKEN.Enum(),
-		Username: proto.String(username),
 		AuthData: []byte(token),
-	})
+	}
+	// The device authorization flow's token response carries no username. Leave
+	// the field unset in that case and let the accesspoint derive it from the
+	// token, rather than sending an empty string.
+	if username != "" {
+		creds.Username = proto.String(username)
+	}
+	return ap.Connect(ctx, creds)
 }
 
 func (ap *Accesspoint) ConnectStored(ctx context.Context, username string, data []byte) error {

--- a/config_schema.json
+++ b/config_schema.json
@@ -225,6 +225,7 @@
               "description": "The authentication method",
               "enum": [
                 "interactive",
+                "device_auth",
                 "spotify_token",
                 "zeroconf"
               ],
@@ -239,6 +240,11 @@
                   "default": 0
                 }
               }
+            },
+            "device_auth": {
+              "type": "object",
+              "description": "Authenticate by entering a code at spotify.com/pair on another device",
+              "properties": {}
             },
             "spotify_token": {
               "type": "object",

--- a/daemon/app.go
+++ b/daemon/app.go
@@ -171,6 +171,8 @@ func (app *App) Run(ctx context.Context) error {
 		return app.runZeroconf(ctx)
 	case "interactive":
 		return app.runInteractive(ctx, app.cfg.Credentials.Interactive.CallbackPort)
+	case "device_auth":
+		return app.runDeviceAuth(ctx)
 	case "spotify_token":
 		return app.runSpotifyToken(ctx, app.cfg.Credentials.SpotifyToken.Username, app.cfg.Credentials.SpotifyToken.AccessToken)
 	default:
@@ -313,6 +315,10 @@ func (app *App) runSpotifyToken(ctx context.Context, username, token string) err
 
 func (app *App) runInteractive(ctx context.Context, callbackPort int) error {
 	return app.withCredentials(ctx, session.InteractiveCredentials{CallbackPort: callbackPort})
+}
+
+func (app *App) runDeviceAuth(ctx context.Context) error {
+	return app.withCredentials(ctx, session.DeviceAuthCredentials{})
 }
 
 func (app *App) withCredentials(ctx context.Context, creds any) (err error) {

--- a/session/oauth2.go
+++ b/session/oauth2.go
@@ -4,9 +4,63 @@ import (
 	"context"
 	"fmt"
 	librespot "github.com/devgianlu/go-librespot"
+	"golang.org/x/oauth2"
+	spotifyoauth2 "golang.org/x/oauth2/spotify"
 	"net"
 	"net/http"
 )
+
+// deviceAuthURL is Spotify's RFC 8628 device authorization endpoint. It is not
+// part of golang.org/x/oauth2/spotify's Endpoint, so it is spelled out here.
+//
+// Spotify only enables the device flow for some client IDs, and rejects the
+// others with unauthorized_client. Ours is accepted.
+const deviceAuthURL = "https://accounts.spotify.com/oauth2/device/authorize"
+
+// oauthScopes is the set of scopes requested by every OAuth flow here.
+var oauthScopes = []string{
+	"app-remote-control",
+	"playlist-modify",
+	"playlist-modify-private",
+	"playlist-modify-public",
+	"playlist-read",
+	"playlist-read-collaborative",
+	"playlist-read-private",
+	"streaming",
+	"ugc-image-upload",
+	"user-follow-modify",
+	"user-follow-read",
+	"user-library-modify",
+	"user-library-read",
+	"user-modify",
+	"user-modify-playback-state",
+	"user-modify-private",
+	"user-personalized",
+	"user-read-birthdate",
+	"user-read-currently-playing",
+	"user-read-email",
+	"user-read-play-history",
+	"user-read-playback-position",
+	"user-read-playback-state",
+	"user-read-private",
+	"user-read-recently-played",
+	"user-top-read",
+}
+
+// newOAuthConfig builds the Spotify OAuth2 config. redirectURL is empty for
+// flows that never redirect a user agent, such as the device flow.
+func newOAuthConfig(redirectURL string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:    librespot.ClientIdHex,
+		RedirectURL: redirectURL,
+		Scopes:      oauthScopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:       spotifyoauth2.Endpoint.AuthURL,
+			TokenURL:      spotifyoauth2.Endpoint.TokenURL,
+			DeviceAuthURL: deviceAuthURL,
+		},
+	}
+}
 
 func NewOAuth2Server(ctx context.Context, log librespot.Logger, callbackPort int) (int, chan string, error) {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", callbackPort))

--- a/session/options.go
+++ b/session/options.go
@@ -39,6 +39,11 @@ type InteractiveCredentials struct {
 	CallbackPort int
 }
 
+// DeviceAuthCredentials authenticates with the OAuth 2.0 device authorization
+// flow: Spotify issues a code that the user enters on another device. Nothing
+// listens on a port and no browser is needed on this machine.
+type DeviceAuthCredentials struct{}
+
 type SpotifyTokenCredentials struct {
 	Username string
 	Token    string

--- a/session/session.go
+++ b/session/session.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devgianlu/go-librespot/mercury"
 	"github.com/devgianlu/go-librespot/player"
 
-	librespot "github.com/devgianlu/go-librespot"
 	"github.com/devgianlu/go-librespot/ap"
 	"github.com/devgianlu/go-librespot/apresolve"
 	"github.com/devgianlu/go-librespot/audio"
@@ -21,7 +20,6 @@ import (
 	credentialspb "github.com/devgianlu/go-librespot/proto/spotify/login5/v3/credentials"
 	"github.com/devgianlu/go-librespot/spclient"
 	"golang.org/x/oauth2"
-	spotifyoauth2 "golang.org/x/oauth2/spotify"
 )
 
 type Session struct {
@@ -110,39 +108,7 @@ func NewSessionFromOptions(ctx context.Context, opts *Options) (*Session, error)
 			return nil, fmt.Errorf("failed initializing oauth2 server: %w", err)
 		}
 
-		oauthConf := &oauth2.Config{
-			ClientID:    librespot.ClientIdHex,
-			RedirectURL: fmt.Sprintf("http://127.0.0.1:%d/login", callbackPort),
-			Scopes: []string{
-				"app-remote-control",
-				"playlist-modify",
-				"playlist-modify-private",
-				"playlist-modify-public",
-				"playlist-read",
-				"playlist-read-collaborative",
-				"playlist-read-private",
-				"streaming",
-				"ugc-image-upload",
-				"user-follow-modify",
-				"user-follow-read",
-				"user-library-modify",
-				"user-library-read",
-				"user-modify",
-				"user-modify-playback-state",
-				"user-modify-private",
-				"user-personalized",
-				"user-read-birthdate",
-				"user-read-currently-playing",
-				"user-read-email",
-				"user-read-play-history",
-				"user-read-playback-position",
-				"user-read-playback-state",
-				"user-read-private",
-				"user-read-recently-played",
-				"user-top-read",
-			},
-			Endpoint: spotifyoauth2.Endpoint,
-		}
+		oauthConf := newOAuthConfig(fmt.Sprintf("http://127.0.0.1:%d/login", callbackPort))
 
 		verifier := oauth2.GenerateVerifier()
 		url := oauthConf.AuthCodeURL("", oauth2.S256ChallengeOption(verifier))
@@ -164,6 +130,32 @@ func NewSessionFromOptions(ctx context.Context, opts *Options) (*Session, error)
 
 		if err := s.ap.ConnectSpotifyToken(ctx, token.Extra("username").(string), token.AccessToken); err != nil {
 			return nil, fmt.Errorf("failed authenticating accesspoint interactively: %w", err)
+		}
+	case DeviceAuthCredentials:
+		oauthConf := newOAuthConfig("")
+
+		da, err := oauthConf.DeviceAuth(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed requesting device code: %w", err)
+		}
+
+		verificationUrl := da.VerificationURIComplete
+		if verificationUrl == "" {
+			verificationUrl = da.VerificationURI
+		}
+		opts.Log.Infof("to complete authentication visit %s and, if prompted, enter code %s", verificationUrl, da.UserCode)
+
+		// Blocks until the user approves or declines, or the code expires.
+		token, err := oauthConf.DeviceAccessToken(ctx, da)
+		if err != nil {
+			return nil, fmt.Errorf("failed exchanging device code: %w", err)
+		}
+
+		// Unlike the authorization code flow, the device flow token response
+		// carries no username. The accesspoint derives one from the token.
+		username, _ := token.Extra("username").(string)
+		if err := s.ap.ConnectSpotifyToken(ctx, username, token.AccessToken); err != nil {
+			return nil, fmt.Errorf("failed authenticating accesspoint with device authorization: %w", err)
 		}
 	case SpotifyTokenCredentials:
 		if err := s.ap.ConnectSpotifyToken(ctx, creds.Username, creds.Token); err != nil {


### PR DESCRIPTION
Adds the [OAuth 2.0 device authorization flow](https://oauth.net/2/device-flow/). This flow uses a code entered at https://spotify.com/pair which is normally used to sign into the desktop (via QR code), TV and wearable apps. It doesn't require a callback so it's a lot more convenient for headless use cases like a smart speaker.

When running `go-librespot` with `credentials.type` set to `device_auth`, it will present the pairing URL and code like so:
```
time="2026-08-18T16:26:24-07:00" level=info msg="running go-librespot d178ea4a"
time="2026-08-18T16:26:24-07:00" level=info msg="generated new device id: 275750846b2261642197xxxxxxxxxxxxxxxxxxxx"
time="2026-08-18T16:26:24-07:00" level=info msg="to complete authentication visit https://spotify.com/pair?code=XXXXXX and, if prompted, enter code XXXXXX"
```
then in the background it'll keep polling Spotify for the pairing/login result. When the user finishes logging in and clicks pair, Spotify hands the oauth access and refresh tokens for the user's account to go-librespot on the next poll and stores the creds for future relaunches.

One note about this flow, only client IDs that are whitelisted by Spotify are able to use it. So far I've found that the desktop, TV and wearable client IDs can use it but Android, iOS and web can't. Since go-librespot uses the desktop ID it should work as-is.